### PR TITLE
fix(frontend-models): correct all template paths

### DIFF
--- a/django_sysconfig/frontend_models.py
+++ b/django_sysconfig/frontend_models.py
@@ -25,7 +25,7 @@ class BaseFrontendModel(ABC):
     and extracting the submitted value from the request.
     """
 
-    template_name: str = "config/frontend_models/base.html"
+    template_name: str = "django_sysconfig/frontend_models/base.html"
 
     def __init__(self, field, current_value: Any = None):
         """
@@ -90,7 +90,7 @@ class BaseFrontendModel(ABC):
 class StringFrontendModel(BaseFrontendModel):
     """Frontend model for text/string inputs."""
 
-    template_name = "config/frontend_models/string.html"
+    template_name = "django_sysconfig/frontend_models/string.html"
 
     def get_value(self, raw_value: str | None) -> str | None:
         if raw_value is None or raw_value == "":
@@ -101,7 +101,7 @@ class StringFrontendModel(BaseFrontendModel):
 class TextareaFrontendModel(BaseFrontendModel):
     """Frontend model for multi-line text inputs."""
 
-    template_name = "config/frontend_models/textarea.html"
+    template_name = "django_sysconfig/frontend_models/textarea.html"
 
     def get_value(self, raw_value: str | None) -> str | None:
         if raw_value is None or raw_value == "":
@@ -112,7 +112,7 @@ class TextareaFrontendModel(BaseFrontendModel):
 class IntegerFrontendModel(BaseFrontendModel):
     """Frontend model for integer number inputs."""
 
-    template_name = "config/frontend_models/integer.html"
+    template_name = "django_sysconfig/frontend_models/integer.html"
 
     def get_value(self, raw_value: str | None) -> int | None:
         if raw_value is None or raw_value == "":
@@ -131,7 +131,7 @@ class IntegerFrontendModel(BaseFrontendModel):
 class DecimalFrontendModel(BaseFrontendModel):
     """Frontend model for decimal number inputs."""
 
-    template_name = "config/frontend_models/decimal.html"
+    template_name = "django_sysconfig/frontend_models/decimal.html"
 
     def get_context(self) -> dict:
         context = super().get_context()
@@ -156,7 +156,7 @@ class DecimalFrontendModel(BaseFrontendModel):
 class BooleanFrontendModel(BaseFrontendModel):
     """Frontend model for boolean checkbox inputs."""
 
-    template_name = "config/frontend_models/boolean.html"
+    template_name = "django_sysconfig/frontend_models/boolean.html"
 
     def get_context(self) -> dict:
         context = super().get_context()
@@ -198,7 +198,7 @@ class BooleanFrontendModel(BaseFrontendModel):
 class SelectFrontendModel(BaseFrontendModel):
     """Frontend model for dropdown select inputs."""
 
-    template_name = "config/frontend_models/select.html"
+    template_name = "django_sysconfig/frontend_models/select.html"
 
     def get_context(self) -> dict:
         context = super().get_context()
@@ -223,7 +223,7 @@ class SecretFrontendModel(BaseFrontendModel):
     - Shows placeholder when value exists, never displays actual value
     """
 
-    template_name = "config/frontend_models/secret.html"
+    template_name = "django_sysconfig/frontend_models/secret.html"
 
     # Placeholder shown when a secret value exists
     SECRET_PLACEHOLDER = "••••••••••••••••••••••••"


### PR DESCRIPTION
## Description

All 7 frontend model classes had `template_name` pointing to `config/frontend_models/*`, which doesn't exist. With `APP_DIRS=True`, Django resolves template paths relative to each app's `templates/` directory, so the correct prefix is `django_sysconfig/frontend_models/`. This caused `TemplateDoesNotExist` on every field render, making the entire config admin UI broken.

Closes #1

---

## Type of Change

- [x] 🐛 Bug fix

---

## Changes Made

- Changed `template_name` on all 7 frontend model classes from `config/frontend_models/*` to `django_sysconfig/frontend_models/*`

---

## Django / Python Compatibility

- [ ] Not applicable (template path fix, no logic change)

---

## Checklist

- [x] My code follows the existing code style
- [x] All existing tests pass
- [x] No migrations needed
- [ ] I have added or updated tests to cover my changes

---

## Breaking Changes

N/A