### PR TITLE
fix(views): skip blank secret fields on POST to avoid wiping stored secrets

### DIFF
--- a/django_sysconfig/views.py
+++ b/django_sysconfig/views.py
@@ -12,6 +12,7 @@ from django.utils.decorators import method_decorator
 from django.views import View
 
 from .accessor import config
+from .frontend_models import SecretFrontendModel
 from .models import ConfigValue
 from .registry import config_registry
 from .validators import validate_value
@@ -168,6 +169,14 @@ class ConfigAppDetailView(View):
 
                 # Get and process value
                 processed_value = self._get_processed_value(request, field, input_name)
+
+                # Skip blank secret fields — an empty submission means "no change";
+                # saving None would wipe the previously stored encrypted value.
+                if (
+                    issubclass(field.frontend_model, SecretFrontendModel)
+                    and (processed_value is None or processed_value == "")
+                ):
+                    continue
 
                 # Use the accessor to set the value (dot notation)
                 full_path = f"{app_label}.{section_key}.{field_name}"


### PR DESCRIPTION
## Description

When a user submits the config form without entering a new value for a secret field, the password input is blank. Previously this caused `config.set()` to be called with `None`, permanently overwriting the stored encrypted value with nothing.

Closes #3

---

## Type of Change

- [x] 🐛 Bug fix

---

## Changes Made

- Imported `SecretFrontendModel` in `views.py`
- In the POST save loop, check if the field uses `SecretFrontendModel` and the submitted value is blank — if so, skip saving that field entirely so the stored secret is preserved

---

## Django / Python Compatibility

- [ ] Tested on Django 4.2 (LTS)
- [ ] Tested on Django 5.x
- [x] Tested on Python 3.11+
- [ ] Not applicable

---

## Checklist

- [x] My code follows the existing code style
- [ ] I have added or updated tests to cover my changes
- [x] All existing tests pass (`python -m pytest` or `python manage.py test`)
- [ ] I have updated the documentation if needed
- [ ] I have added an entry to `CHANGELOG.md` (if user-facing change)
- [x] I have checked for any migrations needed (`makemigrations --check`)

---

## Breaking Changes

N/A

---

## Additional Notes

No functional change for non-secret fields. Secret fields now require an explicit non-blank value to be updated.