### PR TITLE
chore: update pyproject.toml with correct author and URLs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "A Magento-style system configuration app for Django"
 readme = "README.md"
 license = { text = "MIT" }
-authors = [{ name = "Your Name", email = "you@example.com" }]
+authors = [{ name = "Krishna Modepalli" }]
 keywords = ["django", "configuration", "settings", "admin"]
 classifiers = [
     "Development Status :: 3 - Alpha",
@@ -44,9 +44,9 @@ dev = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/yourusername/django-sysconfig"
-Repository = "https://github.com/yourusername/django-sysconfig"
-Issues = "https://github.com/yourusername/django-sysconfig/issues"
+Homepage = "https://github.com/krishnamodepalli/django-sysconfig"
+Repository = "https://github.com/krishnamodepalli/django-sysconfig"
+Issues = "https://github.com/krishnamodepalli/django-sysconfig/issues"
 
 [tool.hatch.build.targets.wheel]
 packages = ["django_sysconfig"]


### PR DESCRIPTION
## Description

Consolidates all project setup improvements:

1. Updated `pyproject.toml` with the real author name and repository URLs
2. Replaced Postgres with SQLite for the dev server — eliminates Docker friction for local development
3. Removed `psycopg2-binary` and `python-dotenv` from dev deps (no longer needed); added `pre-commit`
4. Added `CONTRIBUTING.md` with full local setup guide, dev server instructions, code style notes, and PR workflow
5. Added a Contributing section to `README.md` linking to `CONTRIBUTING.md`

---

## Type of Change

- [x] 🔧 Internal refactor (no behaviour change)
- [x] 📖 Documentation update

---

## Changes Made

- `pyproject.toml`: real author + URLs, cleaned up dev deps
- `settings_dev.py`: SQLite instead of Postgres, removed dotenv, added demo app
- `CONTRIBUTING.md`: new — full contributor/dev setup guide
- `README.md`: added Contributing section

---

## Django / Python Compatibility

- [x] Not applicable

---

## Checklist

- [x] My code follows the existing code style
- [ ] I have added or updated tests to cover my changes
- [x] All existing tests pass (`python -m pytest` or `python manage.py test`)
- [x] I have updated the documentation if needed
- [ ] I have added an entry to `CHANGELOG.md` (if user-facing change)
- [x] I have checked for any migrations needed (`makemigrations --check`)

---

## Breaking Changes

N/A — dev-only changes, no impact on the published package.

---

## Additional Notes

After merging, local dev setup is simply:
```bash
pip install -e ".[dev]"
pre-commit install
DJANGO_SETTINGS_MODULE=settings_dev django-admin migrate
DJANGO_SETTINGS_MODULE=settings_dev django-admin createsuperuser
DJANGO_SETTINGS_MODULE=settings_dev django-admin runserver
```