### PR TITLE
ci(release): use RELEASE_TOKEN instead of GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -33,7 +33,7 @@ jobs:
         id: release
         uses: python-semantic-release/python-semantic-release@v9
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.RELEASE_TOKEN }}
 
   publish:
     name: Publish to PyPI


### PR DESCRIPTION
## Description

`GITHUB_TOKEN` is rejected by GitHub when trying to push directly to a branch with protection rules. Swapping to `RELEASE_TOKEN` (a PAT stored as a repository secret) which has the required `contents: write` permissions to allow `python-semantic-release` to push the version bump commit and tag.

---

## Type of Change

- [x] ⚙️ CI/CD change

---

## Changes Made

- `.github/workflows/release.yml`: replaced both `GITHUB_TOKEN` references with `RELEASE_TOKEN` — in the `actions/checkout` token and the `python-semantic-release` `github_token` input

---

## Django / Python Compatibility

- [x] Not applicable

---

## Checklist

- [x] My code follows the existing code style
- [ ] I have added or updated tests to cover my changes
- [x] All existing tests pass (`python -m pytest` or `python manage.py test`)
- [ ] I have updated the documentation if needed
- [ ] I have added an entry to `CHANGELOG.md` (if user-facing change)
- [x] I have checked for any migrations needed (`makemigrations --check`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated authentication configuration in the continuous integration and deployment pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->