### PR TITLE
refactor(frontend_models): Close all input tags used in `frontend_models`

### DIFF
--- a/django_sysconfig/templates/django_sysconfig/frontend_models/boolean.html
+++ b/django_sysconfig/templates/django_sysconfig/frontend_models/boolean.html
@@ -12,7 +12,7 @@
                            name="{{ input_name }}"
                            id="{{ input_id }}"
                            value="1"
-                           {% if checked %}checked{% endif %}>
+                           {% if checked %}checked{% endif %} />
                     <span class="toggle-slider"></span>
                 </span>
                 <span class="toggle-label" id="{{ input_id }}_label">{% if checked %}Yes{% else %}No{% endif %}</span>

--- a/django_sysconfig/templates/django_sysconfig/frontend_models/decimal.html
+++ b/django_sysconfig/templates/django_sysconfig/frontend_models/decimal.html
@@ -13,7 +13,7 @@
                        value="{{ value|default:'' }}"
                        step="{{ step }}"
                        {% if field.extra.min is not None %}min="{{ field.extra.min }}"{% endif %}
-                       {% if field.extra.max is not None %}max="{{ field.extra.max }}"{% endif %}>
+                       {% if field.extra.max is not None %}max="{{ field.extra.max }}"{% endif %} />
             </div>
             {% if field.comment %}
             <div class="config-field-comment">{{ field.comment|safe }}</div>

--- a/django_sysconfig/templates/django_sysconfig/frontend_models/integer.html
+++ b/django_sysconfig/templates/django_sysconfig/frontend_models/integer.html
@@ -13,7 +13,7 @@
                        value="{{ value|default:'' }}"
                        step="1"
                        {% if field.extra.min is not None %}min="{{ field.extra.min }}"{% endif %}
-                       {% if field.extra.max is not None %}max="{{ field.extra.max }}"{% endif %}>
+                       {% if field.extra.max is not None %}max="{{ field.extra.max }}"{% endif %} />
             </div>
             {% if field.comment %}
             <div class="config-field-comment">{{ field.comment|safe }}</div>

--- a/django_sysconfig/templates/django_sysconfig/frontend_models/secret.html
+++ b/django_sysconfig/templates/django_sysconfig/frontend_models/secret.html
@@ -12,7 +12,7 @@
                        name="{{ input_name }}"
                        id="{{ input_id }}"
                        value="{% if has_value %}{{ placeholder }}{% endif %}"
-                       autocomplete="new-password">
+                       autocomplete="new-password" />
             </div>
             {% if has_value %}
             <div class="secret-status">

--- a/django_sysconfig/templates/django_sysconfig/frontend_models/string.html
+++ b/django_sysconfig/templates/django_sysconfig/frontend_models/string.html
@@ -12,7 +12,7 @@
                        id="{{ input_id }}"
                        value="{{ value|default:'' }}"
                        {% if field.extra.placeholder %}placeholder="{{ field.extra.placeholder }}"{% endif %}
-                       {% if field.extra.maxlength %}maxlength="{{ field.extra.maxlength }}"{% endif %}>
+                       {% if field.extra.maxlength %}maxlength="{{ field.extra.maxlength }}"{% endif %} />
             </div>
             {% if field.comment %}
             <div class="config-field-comment">{{ field.comment|safe }}</div>


### PR DESCRIPTION
## Description

All the Frontend models in the app have a dedicated html template which is used in the admin configuration page to see and set config values. Their input tags are not closed, even they are self-closing tags. This PR just refactors those files and closes those input tags.

---

## Type of Change

<!-- Check all that apply -->

- [X] 🔧 Internal refactor (no behaviour change)

---

## Changes Made

- Close all the input tags of all the Frontend model html templates

---

## Django / Python Compatibility

<!-- Confirm which versions this has been tested against, or note if untested -->

- [X] Tested on Django 4.2 (LTS)
- [X] Tested on Django 5.x
- [X] Tested on Python 3.11+

---

## Checklist

- [X] My code follows the existing code style
- [ ] I have added or updated tests to cover my changes
- [X] All existing tests pass (`python -m pytest` or `python manage.py test`)
- [X] I have updated the documentation if needed
- [X] I have checked for any migrations needed (`makemigrations --check`)

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized HTML syntax across form field templates by converting input elements to self-closing format for improved code consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->