### PR TITLE
fix(accessor): check for non-empty values in `accessor.is_set` method

### DIFF
--- a/django_sysconfig/accessor.py
+++ b/django_sysconfig/accessor.py
@@ -271,7 +271,6 @@ class ConfigAccessor:
             count += 1
         return count
 
-    # TODO: This method should be made private
     def all(self, app_label: str) -> dict[str, dict[str, Any]]:
         """
         Get all configuration values for an app.
@@ -308,7 +307,6 @@ class ConfigAccessor:
 
         return result
 
-    # TODO: This method should be made private
     def section(self, path: str) -> dict[str, Any]:
         """
         Get all configuration values for a specific section.


### PR DESCRIPTION
## Description

The `is_set()` method now verifies that ConfigValue.value is not None and not an empty string, not just that the database row exists.

This ensures is_set() correctly distinguishes between "explicitly set to a value" vs "using default or empty".

---

## Type of Change

<!-- Check all that apply -->

- [X] 🐛 Bug fix

---

## Changes Made

- `is_set()` method in the accessor now verifies if the value is empty

---

## Django / Python Compatibility

<!-- Confirm which versions this has been tested against, or note if untested -->

- [X] Tested on Django 4.2 (LTS)
- [X] Tested on Django 5.x
- [X] Tested on Python 3.11+

---

## Checklist

- [X] My code follows the existing code style
- [ ] I have added or updated tests to cover my changes
- [X] All existing tests pass (`python -m pytest` or `python manage.py test`)
- [X] I have updated the documentation if needed
- [X] I have added an entry to `CHANGELOG.md` (if user-facing change)
- [X] I have checked for any migrations needed (`makemigrations --check`)

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration detection: existence checks now validate that a config field is registered before reporting present.
  * is_set now treats values that are None or empty strings as unset and returns False for unregistered or missing rows, preventing false-positive detections.
  * No changes to public APIs or method signatures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->