### PR TITLE
feat: Make the config views extendable with extra permissions

### DIFF
--- a/django_sysconfig/views.py
+++ b/django_sysconfig/views.py
@@ -54,9 +54,12 @@ class BaseConfigView(View):
         return True
 
     def dispatch(self, request, *args, **kwargs):
-        if not request.user.is_authenticated or not request.user.is_staff:
-            raise PermissionDenied
-        if not self.has_extra_permissions(request):
+        if not request.user.is_authenticated:
+            from django.contrib.auth.views import redirect_to_login
+
+            return redirect_to_login(request.get_full_path())
+
+        if not request.user.is_staff or not self.has_extra_permissions(request):
             raise PermissionDenied
 
         return super().dispatch(request, *args, **kwargs)


### PR DESCRIPTION
## Description
Made both the Config Views (List Config Apps View & Detailed App Config View) extendable for extra permissions from any other app.

---

## Type of Change

<!-- Check all that apply -->

- [X] ✨ New feature

---

## Changes Made

- Created a new `BaseConfigView` which has some default permissions to access the config views.
- The default permissions are **User should be authenticated** and **User should be a staff**

---

## Django / Python Compatibility

<!-- Confirm which versions this has been tested against, or note if untested -->

- [x] Tested on Django 4.2 (LTS)
- [X] Tested on Django 5.x
- [X] Tested on Python 3.11+

---

## Checklist

- [X] My code follows the existing code style
- [X] I have added or updated tests to cover my changes
- [X] All existing tests pass (`python -m pytest` or `python manage.py test`)
- [X] I have checked for any migrations needed (`makemigrations --check`)

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced access control mechanisms for configuration management views, ensuring consistent staff-only access enforcement across the platform with extensible permission checking capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->