### PR TITLE
fix(encryption): is_encrypted() uses an unreliable length heuristic

### DIFF
--- a/django_sysconfig/encryption.py
+++ b/django_sysconfig/encryption.py
@@ -63,9 +63,12 @@ def decrypt(encrypted_value: str) -> str:
 
 def is_encrypted(value: str) -> bool:
     """
-    Check if a value appears to be encrypted.
+    Check if a value appears to be a Fernet-encrypted token.
 
-    This is a heuristic check - Fernet tokens have a specific format.
+    Uses two heuristics: minimum decoded length and the Fernet version
+    byte (0x80), which is always the first byte of a valid Fernet token.
+    This eliminates false positives from other long base64-encoded values
+    such as JWTs, hashed passwords, or long API keys.
 
     Args:
         value: The value to check
@@ -76,12 +79,9 @@ def is_encrypted(value: str) -> bool:
     if not value:
         return False
     try:
-        # Fernet tokens are base64-encoded and start with 'gAAAAA'
-        # They also have a specific length pattern
         decoded = base64.urlsafe_b64decode(value.encode())
-        return len(decoded) >= MIN_FERNET_TOKEN_SIZE
+        return len(decoded) >= MIN_FERNET_TOKEN_SIZE and decoded[0] == 0x80
     except (ValueError, TypeError, UnicodeDecodeError):
-        # Invalid base64 or encoding issues mean it's not encrypted
         return False
 
 


### PR DESCRIPTION
## Description

changes:
- Now `is_encrypted()` method uses two heuristic, instead of only depending one lenght.
- Both length and the decoded format starting with `0x80`.

Closes #10 

---

## Type of Change

<!-- Check all that apply -->

- [X] 🐛 Bug fix

---

## Changes Made

- Updated the `is_encrypted()` method to depend on two heuristics (length and string starts with) instead of one (length)

---

## Django / Python Compatibility

<!-- Confirm which versions this has been tested against, or note if untested -->

- [X] Tested on Django 4.2 (LTS)
- [X] Tested on Django 5.x
- [X] Tested on Python 3.11+

---

## Checklist

- [X] My code follows the existing code style
- [ ] I have added or updated tests to cover my changes
- [X] All existing tests pass (`python -m pytest` or `python manage.py test`)
- [X] I have updated the documentation if needed

---

## Additional Notes

`is_encrypted()` will always be a ambiguous thing. But with two of the validations, its just a little better.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced encryption validation logic with additional integrity checks.

* **Documentation**
  * Updated related comments and descriptive text to reflect improved validation approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->