### PR TITLE
chore: update pyproject metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,12 +11,13 @@ license = { text = "MIT" }
 authors = [{ name = "Krishna Modepalli" }]
 keywords = ["django", "configuration", "settings", "admin"]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 5 - Production/Stable",
     "Environment :: Web Environment",
     "Framework :: Django",
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",
     "Framework :: Django :: 5.1",
+    "Framework :: Django :: 5.2",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",


### PR DESCRIPTION
## Description

Update `pyproject.toml` metadata to reflect the project's current maturity and Django support.

Closes #<!-- issue number -->

---

## Type of Change

- [x] 🔧 Internal refactor (no behaviour change)

---

## Changes Made

- Bumps `Development Status` classifier from `3 - Alpha` to `5 - Production/Stable`
- Adds `Framework :: Django :: 5.2` classifier

---

## Django / Python Compatibility

- [x] Not applicable

---

## Checklist

- [x] My code follows the existing code style
- [ ] I have added or updated tests to cover my changes
- [x] All existing tests pass (`python -m pytest` or `python manage.py test`)
- [ ] I have updated the documentation if needed
- [ ] I have added an entry to `CHANGELOG.md` (if user-facing change)
- [x] I have checked for any migrations needed (`makemigrations --check`)

---

## Breaking Changes

N/A

---

## Additional Notes

Metadata-only change. No code, behaviour, or API impact.