### PR TITLE
refactor(admin): replace short_description with @admin.display decorator

### DIFF
--- a/django_sysconfig/admin.py
+++ b/django_sysconfig/admin.py
@@ -18,6 +18,7 @@ class ConfigValueAdmin(admin.ModelAdmin):
     ordering = ("app_label", "path")
     readonly_fields = ("app_label", "path", "value_preview")
 
+    @admin.display(description="Value")
     def value_preview(self, obj):
         """Show value preview, masking secrets."""
         if not obj.value:
@@ -32,5 +33,3 @@ class ConfigValueAdmin(admin.ModelAdmin):
         if len(obj.value) > PREVIEW_MAX_LENGTH:
             return obj.value[:PREVIEW_MAX_LENGTH] + "..."
         return obj.value
-
-    value_preview.short_description = "Value"


### PR DESCRIPTION
## Description
Replaces the deprecated `short_description` function attribute with the `@admin.display` decorator on `ConfigAdmin.colored_value`.

Closes #34

---
## Type of Change
- [x] 🔧 Internal refactor (no behaviour change)

---
## Changes Made
- `django_sysconfig/admin.py`: added `@admin.display(description="Value")` decorator to `colored_value`
- Removed `colored_value.short_description = "Value"` attribute assignment

---
## Django / Python Compatibility
- [x] Not applicable

---
## Checklist
- [x] My code follows the existing code style
- [x] All existing tests pass (`python -m pytest` or `python manage.py test`)
- [ ] I have added or updated tests to cover my changes
- [ ] I have added an entry to `CHANGELOG.md` (if user-facing change)

---
## Breaking Changes
N/A

---
## Additional Notes
`short_description` as a function attribute was deprecated in Django 3.2 in favour of the `@admin.display` decorator. This change modernises the code with no behaviour change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated admin interface configuration with no changes to user-facing functionality or appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->