### PR TITLE
fix(registry): log warning instead of silently passing DB errors in _ensure_db_records

### DIFF
--- a/django_sysconfig/admin.py
+++ b/django_sysconfig/admin.py
@@ -18,7 +18,6 @@ class ConfigValueAdmin(admin.ModelAdmin):
     ordering = ("app_label", "path")
     readonly_fields = ("app_label", "path", "value_preview")
 
-    @admin.display(description="Value")
     def value_preview(self, obj):
         """Show value preview, masking secrets."""
         if not obj.value:
@@ -33,3 +32,5 @@ class ConfigValueAdmin(admin.ModelAdmin):
         if len(obj.value) > PREVIEW_MAX_LENGTH:
             return obj.value[:PREVIEW_MAX_LENGTH] + "..."
         return obj.value
+
+    value_preview.short_description = "Value"

--- a/django_sysconfig/admin.py
+++ b/django_sysconfig/admin.py
@@ -18,6 +18,7 @@ class ConfigValueAdmin(admin.ModelAdmin):
     ordering = ("app_label", "path")
     readonly_fields = ("app_label", "path", "value_preview")
 
+    @admin.display(description="Value")
     def value_preview(self, obj):
         """Show value preview, masking secrets."""
         if not obj.value:
@@ -32,5 +33,3 @@ class ConfigValueAdmin(admin.ModelAdmin):
         if len(obj.value) > PREVIEW_MAX_LENGTH:
             return obj.value[:PREVIEW_MAX_LENGTH] + "..."
         return obj.value
-
-    value_preview.short_description = "Value"

--- a/django_sysconfig/registry.py
+++ b/django_sysconfig/registry.py
@@ -26,6 +26,7 @@ Usage:
             )
 """
 
+import logging
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
@@ -37,6 +38,8 @@ from .utils import is_snake_case, to_snake_case
 if TYPE_CHECKING:
     from .frontend_models import BaseFrontendModel
     from .validators import BaseValidator
+
+logger = logging.getLogger(__name__)
 
 
 class Field:
@@ -279,10 +282,13 @@ class ConfigRegistry:
         except (
             django.db.utils.OperationalError,
             django.db.utils.ProgrammingError,
-        ):
-            # Silently ignore DB errors during startup (e.g., migrations not run yet)
-            # This is expected during initial app loading before migrations are applied
-            pass
+        ) as e:
+            logger.warning(
+                "django-sysconfig: could not seed DB records for '%s' — "
+                "run migrations if this is a fresh install. Error: %s",
+                app_label,
+                e,
+            )
 
     def get_config(self, app_label: str) -> AppConfigDefinition | None:
         """Get the configuration definition for an app."""


### PR DESCRIPTION
## Description
`_ensure_db_records()` was silently swallowing `OperationalError` and `ProgrammingError` with a bare `pass`, giving operators no signal when DB seeding failed at startup.

This replaces the silent `pass` with a `logger.warning(...)` call that preserves the tolerant-startup behaviour while making the failure visible in logs.

Closes #73

---
## Type of Change
- [x] 🐛 Bug fix

---
## Changes Made
- Added `import logging` and module-level `logger = logging.getLogger(__name__)` to `registry.py`
- Replaced bare `pass` in the except block with `logger.warning(...)` including the app_label and exception details

---
## Django / Python Compatibility
- [x] Not applicable

---
## Checklist
- [x] My code follows the existing code style
- [x] All existing tests pass (`pytest` — 336 passed)

---
## Breaking Changes
N/A

---
## Additional Notes
The warning message format matches the maintainer's suggestion in the issue description exactly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Database initialization now logs warnings when errors occur.

* **Style**
  * Admin interface updated to use modern Django conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->