### PR TITLE
refactor(registry): remove redundant __init_subclass__ from Section

### DIFF
--- a/django_sysconfig/admin.py
+++ b/django_sysconfig/admin.py
@@ -18,7 +18,6 @@ class ConfigValueAdmin(admin.ModelAdmin):
     ordering = ("app_label", "path")
     readonly_fields = ("app_label", "path", "value_preview")
 
-    @admin.display(description="Value")
     def value_preview(self, obj):
         """Show value preview, masking secrets."""
         if not obj.value:
@@ -33,3 +32,5 @@ class ConfigValueAdmin(admin.ModelAdmin):
         if len(obj.value) > PREVIEW_MAX_LENGTH:
             return obj.value[:PREVIEW_MAX_LENGTH] + "..."
         return obj.value
+
+    value_preview.short_description = "Value"

--- a/django_sysconfig/admin.py
+++ b/django_sysconfig/admin.py
@@ -18,6 +18,7 @@ class ConfigValueAdmin(admin.ModelAdmin):
     ordering = ("app_label", "path")
     readonly_fields = ("app_label", "path", "value_preview")
 
+    @admin.display(description="Value")
     def value_preview(self, obj):
         """Show value preview, masking secrets."""
         if not obj.value:
@@ -32,5 +33,3 @@ class ConfigValueAdmin(admin.ModelAdmin):
         if len(obj.value) > PREVIEW_MAX_LENGTH:
             return obj.value[:PREVIEW_MAX_LENGTH] + "..."
         return obj.value
-
-    value_preview.short_description = "Value"

--- a/django_sysconfig/registry.py
+++ b/django_sysconfig/registry.py
@@ -144,20 +144,6 @@ class Section(metaclass=SectionMeta):
     sort_order: int = 0
     _fields: dict[str, Field] = {}
 
-    def __init_subclass__(cls, **kwargs):
-        super().__init_subclass__(**kwargs)
-        # Ensure each subclass has its own _fields dict
-        cls._fields = {}
-        for key, value in vars(cls).items():
-            if isinstance(value, Field):
-                if not is_snake_case(key):
-                    raise ImproperlyConfigured(
-                        f"Field name '{key}' in section '{cls.__name__}' must be snake_case "
-                        f"(e.g. 'site_url', 'max_items')."
-                    )
-                value.name = key
-                cls._fields[key] = value
-
     @classmethod
     def get_fields(cls) -> dict[str, Field]:
         """Return all fields in this section, sorted by sort_order."""


### PR DESCRIPTION
## Description
`Section` was populating `_fields` twice — once in `SectionMeta.__new__` and again in `Section.__init_subclass__`. Both blocks did identical work. The `__init_subclass__` method is completely redundant.

Removes `__init_subclass__` and relies solely on `SectionMeta` as the maintainer recommended in the issue comments.

Closes #14

---
## Type of Change
- [x] 🔧 Internal refactor (no behaviour change)

---
## Changes Made
- Removed `__init_subclass__` from `Section` class in `registry.py`

---
## Django / Python Compatibility
- [x] Not applicable

---
## Checklist
- [x] My code follows the existing code style
- [x] All existing tests pass (`pytest` — 336 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modernized Django admin configuration to use current decorator patterns.
  * Improved internal field registration mechanism during class initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->