### PR TITLE
docs(contributing): clarify issue assignment workflow and PR guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,9 @@ This ensures no two contributors spend time on the same problem.
 
 1. Cut a branch off from `develop` — use the convention `feat/typed-accessor` or `fix/accessor-get-fail-with-field-param`
 2. Make your changes, ensure `pytest` passes and `pre-commit run --all-files` is clean
-3. Open a PR against `develop` and include `closes #<issue-number>` in the description
+3. Open a PR against `develop` using the PR template — fill in as much as you can:
+   - **Required:** Description, `closes #N`, Type of Change, Changes Made, Checklist
+   - **Optional:** Django/Python Compatibility (skip if not applicable), Breaking Changes, Additional Notes
 4. Assign yourself as the **Assignee**
 5. Assign a maintainer as **Reviewer**
 6. Keep PRs focused — one issue per PR. If you find a related bug while working, open a separate issue for it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,14 +60,36 @@ Examples:
 
 ---
 
+## Before you start working
+
+**Check the issue tracker first.** Someone else may already be working on the same thing — duplicate PRs create unnecessary review overhead for maintainers.
+
+1. Browse [open issues](https://github.com/krishnamodepalli/django-sysconfig/issues). Look for ones labelled `good first issue` if you're new.
+2. If an issue exists for what you want to work on, comment on it and ask to be assigned. Wait for a maintainer to assign it to you before starting.
+3. If no issue exists, open one first — describe the bug or feature and mention that you'd like to work on it. A maintainer will assign it if it's a good fit.
+
+This ensures no two contributors spend time on the same problem.
+
+---
+
 ## Submitting a PR
 
-1. Branch off `master`: `fix/my-fix` or `feat/my-feature`
-2. Make changes, ensure `pytest` passes
-3. Open a PR against `master`
+1. Cut a branch off from `develop` — use the convention `feat/typed-accessor` or `fix/accessor-get-fail-with-field-param`
+2. Make your changes, ensure `pytest` passes and `pre-commit run --all-files` is clean
+3. Open a PR against `develop` and include `closes #<issue-number>` in the description
+4. Assign yourself as the **Assignee**
+5. Assign `@krishnamodepalli` or `@Shivaram4011` as **Reviewers**
+6. Keep PRs focused — one issue per PR. If you find a related bug while working, open a separate issue for it.
 
 ---
 
 ## Reporting issues
 
-Open an issue on [GitHub Issues](https://github.com/krishnamodepalli/django-sysconfig/issues) with Django/Python versions, a minimal reproduction, and expected vs actual behaviour.
+Open an issue on [GitHub Issues](https://github.com/krishnamodepalli/django-sysconfig/issues) with:
+- Django and Python versions
+- A minimal reproduction
+- Expected vs actual behaviour
+
+Apply the most relevant label (`bug`, `enhancement`, `good first issue`, etc.) if you have triage access. If not, a maintainer will label it.
+
+For security vulnerabilities, do **not** open a public issue — contact the maintainers directly.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,4 +94,4 @@ Open an issue on [GitHub Issues](https://github.com/krishnamodepalli/django-sysc
 
 Apply the most relevant label (`bug`, `enhancement`, `good first issue`, etc.) if you have triage access. If not, a maintainer will label it.
 
-For security vulnerabilities, do **not** open a public issue — contact the maintainers directly.
+For security vulnerabilities, do **not** open a public issue — use [GitHub Security Advisories](https://github.com/krishnamodepalli/django-sysconfig/security/advisories/new) to report privately.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,7 @@ This ensures no two contributors spend time on the same problem.
 2. Make your changes, ensure `pytest` passes and `pre-commit run --all-files` is clean
 3. Open a PR against `develop` and include `closes #<issue-number>` in the description
 4. Assign yourself as the **Assignee**
-5. Assign `@krishnamodepalli` or `@Shivaram4011` as **Reviewers**
+5. Assign a maintainer as **Reviewer**
 6. Keep PRs focused — one issue per PR. If you find a related bug while working, open a separate issue for it.
 
 ---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,8 @@ This ensures no two contributors spend time on the same problem.
    - **Optional:** Django/Python Compatibility (skip if not applicable), Breaking Changes, Additional Notes
 4. Assign yourself as the **Assignee**
 5. Assign a maintainer as **Reviewer**
-6. Keep PRs focused — one issue per PR. If you find a related bug while working, open a separate issue for it.
+6. Add appropriate labels for the PR. E.g. `bug`, `enhancement`, `code-quality`, etc.
+7. Keep PRs focused — one issue per PR. If you find a related bug while working, open a separate issue for it.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds a **"Before you start working"** section — contributors must check open issues, ask to be assigned, and wait before starting work. Prevents duplicate PRs on the same issue.
- Adds `pre-commit run --all-files` to the PR checklist
- Adds `closes #N` reminder in PR steps
- Adds one-issue-per-PR rule
- Adds label guidance and security vulnerability private disclosure note to the reporting section

## Test plan

- [x] Read through the updated CONTRIBUTING.md and verify the workflow is clear for a first-time contributor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "Before you start working" checklist; updated PR submission flow to target develop, require running pre-commit and tests, use the PR template (include "closes #N"), self-assign as Assignee and add a maintainer as Reviewer, and keep PRs to one issue.
  * Expanded issue-reporting checklist (environment, minimal repro, expected vs actual), guidance on applying labels if triage-capable, and directs security reports to private advisories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->