### PR TITLE
ci: add explicit permissions blocks to workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/reload-pythonanywhere.yml
+++ b/.github/workflows/reload-pythonanywhere.yml
@@ -5,6 +5,8 @@ on:
     - cron: '0 0 1,15 * *'
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   reload:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

Fixes 3 open CodeQL code scanning alerts for missing `permissions` blocks on GitHub Actions workflows.

Closes https://github.com/krishnamodepalli/django-sysconfig/security/code-scanning/1
Closes https://github.com/krishnamodepalli/django-sysconfig/security/code-scanning/2
Closes https://github.com/krishnamodepalli/django-sysconfig/security/code-scanning/3

---

## Type of Change

- [x] 🔒 Security fix

---

## Changes Made

- `ci.yml` — added `permissions: contents: read` at workflow level (lint and test jobs only need to read code)
- `reload-pythonanywhere.yml` — added `permissions: {}` (only calls an external API, needs no GitHub token access)

---

## Checklist

- [x] My code follows the existing code style
- [x] All existing tests pass
- [x] Not applicable — workflow-only change, no migrations needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security across CI/CD workflows by implementing least-privilege token permission configurations, restricting GitHub Actions token access to only necessary resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->