### PR TITLE
fix(views): catch ConfigError in post() to prevent 500 on serialization failures

### DIFF
--- a/django_sysconfig/admin.py
+++ b/django_sysconfig/admin.py
@@ -18,7 +18,6 @@ class ConfigValueAdmin(admin.ModelAdmin):
     ordering = ("app_label", "path")
     readonly_fields = ("app_label", "path", "value_preview")
 
-    @admin.display(description="Value")
     def value_preview(self, obj):
         """Show value preview, masking secrets."""
         if not obj.value:
@@ -33,3 +32,5 @@ class ConfigValueAdmin(admin.ModelAdmin):
         if len(obj.value) > PREVIEW_MAX_LENGTH:
             return obj.value[:PREVIEW_MAX_LENGTH] + "..."
         return obj.value
+
+    value_preview.short_description = "Value"

--- a/django_sysconfig/admin.py
+++ b/django_sysconfig/admin.py
@@ -18,6 +18,7 @@ class ConfigValueAdmin(admin.ModelAdmin):
     ordering = ("app_label", "path")
     readonly_fields = ("app_label", "path", "value_preview")
 
+    @admin.display(description="Value")
     def value_preview(self, obj):
         """Show value preview, masking secrets."""
         if not obj.value:
@@ -32,5 +33,3 @@ class ConfigValueAdmin(admin.ModelAdmin):
         if len(obj.value) > PREVIEW_MAX_LENGTH:
             return obj.value[:PREVIEW_MAX_LENGTH] + "..."
         return obj.value
-
-    value_preview.short_description = "Value"

--- a/django_sysconfig/views.py
+++ b/django_sysconfig/views.py
@@ -11,7 +11,7 @@ from django.shortcuts import redirect, render
 from django.views import View
 
 from .accessor import config
-from .exceptions import ConfigValidationError
+from .exceptions import ConfigError, ConfigValidationError
 from .models import ConfigValue
 from .registry import config_registry
 
@@ -185,6 +185,9 @@ class ConfigAppDetailView(BaseConfigView):
                 except ConfigValidationError as e:
                     for error in e.errors:
                         messages.error(request, error)
+                    return redirect("django_sysconfig:app_detail", app_label=app_label)
+                except ConfigError as e:
+                    messages.error(request, str(e))
                     return redirect("django_sysconfig:app_detail", app_label=app_label)
                 saved_count += 1
 

--- a/django_sysconfig/views.py
+++ b/django_sysconfig/views.py
@@ -5,6 +5,8 @@ These views provide the admin interface for managing app configurations.
 They are integrated into Django's admin site and require admin permissions.
 """
 
+import logging
+
 from django.contrib import messages
 from django.core.exceptions import PermissionDenied
 from django.shortcuts import redirect, render
@@ -14,6 +16,8 @@ from .accessor import config
 from .exceptions import ConfigError, ConfigValidationError
 from .models import ConfigValue
 from .registry import config_registry
+
+logger = logging.getLogger(__name__)
 
 
 class BaseConfigView(View):
@@ -187,6 +191,7 @@ class ConfigAppDetailView(BaseConfigView):
                         messages.error(request, error)
                     return redirect("django_sysconfig:app_detail", app_label=app_label)
                 except ConfigError as e:
+                    logger.exception("Failed to save config field '%s'", full_path)
                     messages.error(request, str(e))
                     return redirect("django_sysconfig:app_detail", app_label=app_label)
                 saved_count += 1


### PR DESCRIPTION
## Description
`ConfigAppDetailView.post()` only caught `ConfigValidationError`, letting `ConfigValueError` and other `ConfigError` subtypes propagate as HTTP 500.

Added a second `except ConfigError` clause that catches any remaining `ConfigError` subtype, shows a user-facing error message, and redirects back — same flow as `ConfigValidationError`.

Closes #69

---
## Type of Change
- [x] 🐛 Bug fix

---
## Changes Made
- `django_sysconfig/views.py`: added `ConfigError` to imports and widened the except block in `post()`

---
## Django / Python Compatibility
- [x] Not applicable

---
## Checklist
- [x] My code follows the existing code style
- [x] All existing tests pass (`pytest` — 336 passed)

---
## Breaking Changes
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of configuration save errors: when a save fails, users now see a clear error message and are redirected back to the configuration page instead of encountering an unhandled error.
  * Existing validation errors continue to display individual messages for each issue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->