### PR TITLE
docs: restructure CONTRIBUTING.md and add Security section to README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,9 @@ This ensures no two contributors spend time on the same problem.
 
 1. Cut a branch off from `develop` — use the convention `feat/typed-accessor` or `fix/accessor-get-fail-with-field-param`
 2. Make your changes, ensure `pytest` passes and `pre-commit run --all-files` is clean
-3. Open a PR against `develop` and include `closes #<issue-number>` in the description
+3. Open a PR against `develop` using the PR template — fill in as much as you can:
+   - **Required:** Description, `closes #N`, Type of Change, Changes Made, Checklist
+   - **Optional:** Django/Python Compatibility (skip if not applicable), Breaking Changes, Additional Notes
 4. Assign yourself as the **Assignee**
 5. Assign a maintainer as **Reviewer**
 6. Keep PRs focused — one issue per PR. If you find a related bug while working, open a separate issue for it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,14 +60,36 @@ Examples:
 
 ---
 
+## Before you start working
+
+**Check the issue tracker first.** Someone else may already be working on the same thing — duplicate PRs create unnecessary review overhead for maintainers.
+
+1. Browse [open issues](https://github.com/krishnamodepalli/django-sysconfig/issues). Look for ones labelled `good first issue` if you're new.
+2. If an issue exists for what you want to work on, comment on it and ask to be assigned. Wait for a maintainer to assign it to you before starting.
+3. If no issue exists, open one first — describe the bug or feature and mention that you'd like to work on it. A maintainer will assign it if it's a good fit.
+
+This ensures no two contributors spend time on the same problem.
+
+---
+
 ## Submitting a PR
 
-1. Branch off `master`: `fix/my-fix` or `feat/my-feature`
-2. Make changes, ensure `pytest` passes
-3. Open a PR against `master`
+1. Cut a branch off from `develop` — use the convention `feat/typed-accessor` or `fix/accessor-get-fail-with-field-param`
+2. Make your changes, ensure `pytest` passes and `pre-commit run --all-files` is clean
+3. Open a PR against `develop` and include `closes #<issue-number>` in the description
+4. Assign yourself as the **Assignee**
+5. Assign `@krishnamodepalli` or `@Shivaram4011` as **Reviewers**
+6. Keep PRs focused — one issue per PR. If you find a related bug while working, open a separate issue for it.
 
 ---
 
 ## Reporting issues
 
-Open an issue on [GitHub Issues](https://github.com/krishnamodepalli/django-sysconfig/issues) with Django/Python versions, a minimal reproduction, and expected vs actual behaviour.
+Open an issue on [GitHub Issues](https://github.com/krishnamodepalli/django-sysconfig/issues) with:
+- Django and Python versions
+- A minimal reproduction
+- Expected vs actual behaviour
+
+Apply the most relevant label (`bug`, `enhancement`, `good first issue`, etc.) if you have triage access. If not, a maintainer will label it.
+
+For security vulnerabilities, do **not** open a public issue — contact the maintainers directly.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,17 @@
 # Contributing to django-sysconfig
 
+## Before you start
+
+**Check the issue tracker first.** Someone else may already be working on the same thing — duplicate PRs create unnecessary review overhead for maintainers.
+
+1. Browse [open issues](https://github.com/krishnamodepalli/django-sysconfig/issues). Look for ones labelled `good first issue` if you're new.
+2. If an issue exists for what you want to work on, comment on it and ask to be assigned. Wait for a maintainer to assign it to you before starting.
+3. If no issue exists, open one first — describe the bug or feature and mention that you'd like to work on it. A maintainer will assign it if it's a good fit.
+
+This ensures no two contributors spend time on the same problem.
+
+---
+
 ## Setup
 
 Fork the repo, then:
@@ -13,9 +25,7 @@ pre-commit install
 
 No database server or Docker required.
 
----
-
-## Run tests
+**Run the tests:**
 
 ```bash
 pytest
@@ -23,9 +33,7 @@ pytest
 
 Tests use an in-memory SQLite database. All tests should pass before opening a PR.
 
----
-
-## Dev server
+**Start the dev server:**
 
 ```bash
 DJANGO_SETTINGS_MODULE=settings_dev django-admin migrate
@@ -41,52 +49,28 @@ DJANGO_SETTINGS_MODULE=settings_dev django-admin runserver
 
 ---
 
-## Commit messages
-
-Follow [Conventional Commits](https://www.conventionalcommits.org/):
-
-```
-<type>(<scope>): <short description>
-```
-
-Types: `feat`, `fix`, `docs`, `test`, `refactor`, `chore`, `ci`, `perf`, `style`
-
-Examples:
-- `feat(registry): add support for nested sections`
-- `fix(accessor): always raise for invalid paths`
-- `docs: update quickstart`
-
-**PR titles must follow the same format.**
-
----
-
-## Before you start working
-
-**Check the issue tracker first.** Someone else may already be working on the same thing — duplicate PRs create unnecessary review overhead for maintainers.
-
-1. Browse [open issues](https://github.com/krishnamodepalli/django-sysconfig/issues). Look for ones labelled `good first issue` if you're new.
-2. If an issue exists for what you want to work on, comment on it and ask to be assigned. Wait for a maintainer to assign it to you before starting.
-3. If no issue exists, open one first — describe the bug or feature and mention that you'd like to work on it. A maintainer will assign it if it's a good fit.
-
-This ensures no two contributors spend time on the same problem.
-
----
-
 ## Submitting a PR
 
-1. Cut a branch off from `develop` — use the convention `feat/typed-accessor` or `fix/accessor-get-fail-with-field-param`
+1. Cut a branch off `develop` — use the convention `feat/typed-accessor` or `fix/accessor-get-fail`
 2. Make your changes, ensure `pytest` passes and `pre-commit run --all-files` is clean
-3. Open a PR against `develop` using the PR template — fill in as much as you can:
+3. Commit messages must follow [Conventional Commits](https://www.conventionalcommits.org/):
+   ```
+   <type>(<scope>): <short description>
+   ```
+   Types: `feat`, `fix`, `docs`, `test`, `refactor`, `chore`, `ci`, `perf`, `style`
+   — e.g. `fix(accessor): always raise for invalid paths`, `docs: update quickstart`
+4. Open a PR against `develop` using the PR template — fill in as much as you can:
    - **Required:** Description, `closes #N`, Type of Change, Changes Made, Checklist
    - **Optional:** Django/Python Compatibility (skip if not applicable), Breaking Changes, Additional Notes
-4. Assign yourself as the **Assignee**
-5. Assign a maintainer as **Reviewer**
-6. Add appropriate labels for the PR. E.g. `bug`, `enhancement`, `code-quality`, etc.
+5. Assign yourself as the **Assignee** and a maintainer as **Reviewer**
+6. Add appropriate labels — e.g. `bug`, `enhancement`, `code-quality`
 7. Keep PRs focused — one issue per PR. If you find a related bug while working, open a separate issue for it.
+
+**PR titles must follow the same Conventional Commits format.**
 
 ---
 
-## Reporting issues
+## Reporting bugs
 
 Open an issue on [GitHub Issues](https://github.com/krishnamodepalli/django-sysconfig/issues) with:
 - Django and Python versions
@@ -95,4 +79,8 @@ Open an issue on [GitHub Issues](https://github.com/krishnamodepalli/django-sysc
 
 Apply the most relevant label (`bug`, `enhancement`, `good first issue`, etc.) if you have triage access. If not, a maintainer will label it.
 
-For security vulnerabilities, do **not** open a public issue — use [GitHub Security Advisories](https://github.com/krishnamodepalli/django-sysconfig/security/advisories/new) to report privately.
+---
+
+## Security
+
+Please do **not** open a public issue for security vulnerabilities. Report them privately via [GitHub Security Advisories](https://github.com/krishnamodepalli/django-sysconfig/security/advisories/new).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,4 +94,4 @@ Open an issue on [GitHub Issues](https://github.com/krishnamodepalli/django-sysc
 
 Apply the most relevant label (`bug`, `enhancement`, `good first issue`, etc.) if you have triage access. If not, a maintainer will label it.
 
-For security vulnerabilities, do **not** open a public issue — contact the maintainers directly.
+For security vulnerabilities, do **not** open a public issue — use [GitHub Security Advisories](https://github.com/krishnamodepalli/django-sysconfig/security/advisories/new) to report privately.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,7 @@ This ensures no two contributors spend time on the same problem.
 2. Make your changes, ensure `pytest` passes and `pre-commit run --all-files` is clean
 3. Open a PR against `develop` and include `closes #<issue-number>` in the description
 4. Assign yourself as the **Assignee**
-5. Assign `@krishnamodepalli` or `@Shivaram4011` as **Reviewers**
+5. Assign a maintainer as **Reviewer**
 6. Keep PRs focused — one issue per PR. If you find a related bug while working, open a separate issue for it.
 
 ---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,8 @@ This ensures no two contributors spend time on the same problem.
    - **Optional:** Django/Python Compatibility (skip if not applicable), Breaking Changes, Additional Notes
 4. Assign yourself as the **Assignee**
 5. Assign a maintainer as **Reviewer**
-6. Keep PRs focused — one issue per PR. If you find a related bug while working, open a separate issue for it.
+6. Add appropriate labels for the PR. E.g. `bug`, `enhancement`, `code-quality`, etc.
+7. Keep PRs focused — one issue per PR. If you find a related bug while working, open a separate issue for it.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -75,3 +75,9 @@ Full guides, API reference, and examples are in the docs.
 ## Contributing
 
 See [CONTRIBUTING.md](https://github.com/krishnamodepalli/django-sysconfig/blob/develop/CONTRIBUTING.md). Issues and pull requests are welcome.
+
+---
+
+## Security
+
+Please do not open a public issue for security vulnerabilities. Report them privately via [GitHub Security Advisories](https://github.com/krishnamodepalli/django-sysconfig/security/advisories/new).


### PR DESCRIPTION
## Description

Restructures `CONTRIBUTING.md` for clarity and adds a `## Security` section to `README.md`.

The previous structure had sections scattered without a logical reading order — "Before you start" appeared after commit messages, security was buried at the bottom of "Reporting bugs", and setup/tests/dev server were three separate headings. This PR reorganises the file so it follows the contributor's natural journey.

---

## Type of Change

- [x] 📖 Documentation update

---

## Changes Made

- Reduced `CONTRIBUTING.md` from 7 headings to 5, ordered logically: Before you start → Setup → Submitting a PR → Reporting bugs → Security
- Folded tests and dev server into the **Setup** section
- Folded commit message convention into **Submitting a PR** as a numbered step
- Pulled **Security** into its own visible section instead of being buried under "Reporting bugs"
- Added `## Security` to `README.md` so vulnerability reporters can find the private disclosure link without needing to open `CONTRIBUTING.md`

---

## Django / Python Compatibility

- [x] Not applicable

---

## Checklist

- [x] My code follows the existing code style
- [ ] I have added or updated tests to cover my changes
- [x] All existing tests pass (`python -m pytest` or `python manage.py test`)
- [x] I have updated the documentation if needed
- [ ] I have added an entry to `CHANGELOG.md` (if user-facing change)
- [ ] I have checked for any migrations needed (`makemigrations --check`)

---

## Breaking Changes

N/A

---

## Additional Notes

No content was removed — only reorganised and consolidated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidelines with clearer workflow for contributors.
  * Added security reporting guidance directing vulnerability disclosures to GitHub Security Advisories.
  * Enhanced bug reporting process with required checklists and formatting standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->