### PR TITLE
feat: introduce robust test isolation utilities and comprehensive developer testing guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+### Features
+- **testing**: Introduce `override_sysconfig` and `reset_to_defaults` testing utilities for full developer test isolation. Includes comprehensive `django-sysconfig` developer testing guide.
 
 ## v1.0.0 (2026-03-25)
 

--- a/django_sysconfig/__init__.py
+++ b/django_sysconfig/__init__.py
@@ -14,6 +14,7 @@ from .exceptions import (
     FieldNotFoundError,
     InvalidPathError,
 )
+from .test_utils import override_sysconfig
 
 __all__ = [
     "ConfigError",
@@ -21,6 +22,7 @@ __all__ = [
     "FieldNotFoundError",
     "InvalidPathError",
     "ConfigValueError",
+    "override_sysconfig",
 ]
 
 __version__ = "1.0.0"

--- a/django_sysconfig/cache.py
+++ b/django_sysconfig/cache.py
@@ -41,11 +41,32 @@ class ConfigCache:
         cache.delete(self.CACHE_KEY_PREFIX + key)
 
     def clear(self) -> None:
-        """Clear all cache keys matching the prefix. Only works on generic backends that support delete_pattern, otherwise clears all."""
+        """
+        Clear all cache keys matching the prefix.
+
+        On backends supporting delete_pattern (like redis), it deletes matching keys.
+        On LocMemCache (often used in tests), it iterates and removes matching keys.
+        Otherwise, it falls back to cache.clear() which flushes the ENTIRE cache.
+        """
         try:
             cache.delete_pattern(f"{self.CACHE_KEY_PREFIX}*")
         except AttributeError:
-            cache.clear()
+            if hasattr(cache, "_cache"):
+                # Safe individual invalidation for LocMemCache
+                # In testing, the default cache has keys stored via versions.
+                # Find all keys including the sysconfig prefix and invalidate the core key without version
+                keys_to_delete = []
+                for internal_key in list(cache._cache.keys()):
+                    if self.CACHE_KEY_PREFIX in internal_key:
+                        # Extract the key relative to our prefix
+                        # Using partition on our prefix gives us the exact trailing key string
+                        key_subset = internal_key.split(self.CACHE_KEY_PREFIX, 1)[1]
+                        keys_to_delete.append(key_subset)
+                for k in keys_to_delete:
+                    self.invalidate(k)
+            else:
+                # Warning: Nuclear operation on other unknown backends
+                cache.clear()
 
 
 # Singleton instance

--- a/django_sysconfig/cache.py
+++ b/django_sysconfig/cache.py
@@ -40,6 +40,13 @@ class ConfigCache:
         """Invalidate (delete) a cache key."""
         cache.delete(self.CACHE_KEY_PREFIX + key)
 
+    def clear(self) -> None:
+        """Clear all cache keys matching the prefix. Only works on generic backends that support delete_pattern, otherwise clears all."""
+        try:
+            cache.delete_pattern(f"{self.CACHE_KEY_PREFIX}*")
+        except AttributeError:
+            cache.clear()
+
 
 # Singleton instance
 config_cache = ConfigCache()

--- a/django_sysconfig/management/commands/config.py
+++ b/django_sysconfig/management/commands/config.py
@@ -30,7 +30,6 @@ class _JSONEncoder(json.JSONEncoder):
 
 
 class Command(BaseCommand):
-
     help: str = "Interact with django-sysconfig configuration values"
 
     # -----------------------------------------------------------------------
@@ -161,8 +160,7 @@ class Command(BaseCommand):
 
         if not options["force"]:
             self._confirm(
-                f"This will reset '{path}' to its field default. "
-                "This cannot be undone."
+                f"This will reset '{path}' to its field default. This cannot be undone."
             )
 
         try:

--- a/django_sysconfig/migrations/0001_initial.py
+++ b/django_sysconfig/migrations/0001_initial.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = []

--- a/django_sysconfig/registry.py
+++ b/django_sysconfig/registry.py
@@ -300,6 +300,21 @@ class ConfigRegistry:
         """Clear all registered configurations (useful for testing)."""
         self._configs.clear()
 
+    def reset_to_defaults(self) -> None:
+        """
+        Reset all configuration values to their registered defaults.
+
+        Deletes all ConfigValue records from the database and clears the cache.
+        Subsequent config.get() calls will return field defaults from the registry.
+
+        Useful for test cleanup or resetting to a known state.
+        """
+        from .cache import config_cache
+        from .models import ConfigValue
+
+        ConfigValue.objects.all().delete()
+        config_cache.clear()
+
 
 # Global registry instance
 config_registry = ConfigRegistry()

--- a/django_sysconfig/test_utils.py
+++ b/django_sysconfig/test_utils.py
@@ -1,0 +1,114 @@
+from typing import Any
+
+from django.db import transaction
+
+# We must defer importing registry/models/config until runtime
+# to prevent AppRegistryNotReady since this is exported in __init__.py
+
+
+def _resolve_config_path(key: str) -> str:
+    """
+    Resolve a keyword argument key to a full app.section.field path.
+    If the key contains '__', it is treated as replacing '.'.
+    Otherwise, it searches the registry for a unique field with that name.
+    """
+    if "__" in key:
+        return key.replace("__", ".")
+
+    from .registry import config_registry
+
+    # Search for a short name
+    matches = []
+    for app_label, app_config in config_registry.get_all_configs().items():
+        for section_key, section_class in app_config.get_sections():
+            if key in section_class.get_fields():
+                matches.append(f"{app_label}.{section_key}.{key}")
+
+    if not matches:
+        raise ValueError(f"Configuration key '{key}' not found in registry.")
+    if len(matches) > 1:
+        raise ValueError(
+            f"Configuration key '{key}' is ambiguous. Found in: {', '.join(matches)}. "
+            f"Use the full path with '__' (e.g. {matches[0].replace('.', '__')})."
+        )
+    return matches[0]
+
+
+class override_sysconfig:
+    """
+    Decorator and context manager to temporarily override configuration values.
+
+    Changes are persisted to the database and cache. Original values
+    are restored when exiting the context.
+
+    Usage as a context manager:
+        with override_sysconfig(ENABLE_BETA_FEATURES=True, MAX_RETRIES=5):
+            assert config.get('testapp.general.enabled') is True
+
+    Usage as a decorator:
+        @override_sysconfig(ENABLE_BETA_FEATURES=True)
+        def test_beta_logic():
+            pass
+    """
+
+    def __init__(self, **kwargs: Any):
+        self.overrides = {}
+        for k, v in kwargs.items():
+            self.overrides[_resolve_config_path(k)] = v
+        self.saved_state = {}
+
+    def __enter__(self) -> None:
+        self._save_and_apply()
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        self._restore()
+
+    def __call__(self, test_func: Any) -> Any:
+        from functools import wraps
+
+        @wraps(test_func)
+        def inner(*args: Any, **kwargs: Any) -> Any:
+            with self:
+                return test_func(*args, **kwargs)
+
+        return inner
+
+    def _save_and_apply(self) -> None:
+        from .accessor import config
+
+        for path, _ in self.overrides.items():
+            try:
+                self.saved_state[path] = config.get(path)
+            except Exception:
+                self.saved_state[path] = None  # Field didn't exist or wasn't set
+
+        with transaction.atomic():
+            for path, new_value in self.overrides.items():
+                config.set(path, new_value)
+                # In testing, transactions might not commit immediately, so we
+                # manually invalidate the cache to ensure the next .get() sees the new value in DB
+                from .cache import config_cache
+
+                config_cache.invalidate(path)
+
+    def _restore(self) -> None:
+        from .accessor import config
+        from .cache import config_cache
+        from .models import ConfigValue
+
+        with transaction.atomic():
+            for path, original_value in self.saved_state.items():
+                if original_value is None:
+                    # Reset to field default via delete
+                    try:
+                        app_label = path.split(".")[0]
+                        db_path = ".".join(path.split(".")[1:])
+                        ConfigValue.objects.get(
+                            app_label=app_label, path=db_path
+                        ).delete()
+                        config_cache.invalidate(path)
+                    except ConfigValue.DoesNotExist:
+                        pass
+                else:
+                    config.set(path, original_value)
+                    config_cache.invalidate(path)

--- a/django_sysconfig/test_utils.py
+++ b/django_sysconfig/test_utils.py
@@ -57,8 +57,9 @@ class override_sysconfig:
             self.overrides[_resolve_config_path(k)] = v
         self.saved_state = {}
 
-    def __enter__(self) -> None:
+    def __enter__(self) -> "override_sysconfig":
         self._save_and_apply()
+        return self
 
     def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
         self._restore()
@@ -75,20 +76,24 @@ class override_sysconfig:
 
     def _save_and_apply(self) -> None:
         from .accessor import config
+        from .cache import config_cache
+        from .models import ConfigValue
 
         for path, _ in self.overrides.items():
-            try:
+            # Check if there is an existing DB record for the field
+            app_label = path.split(".")[0]
+            db_path = ".".join(path.split(".")[1:])
+
+            if ConfigValue.objects.filter(app_label=app_label, path=db_path).exists():
                 self.saved_state[path] = config.get(path)
-            except Exception:
-                self.saved_state[path] = None  # Field didn't exist or wasn't set
+            else:
+                self.saved_state[path] = config_cache.NOT_FOUND
 
         with transaction.atomic():
             for path, new_value in self.overrides.items():
                 config.set(path, new_value)
                 # In testing, transactions might not commit immediately, so we
                 # manually invalidate the cache to ensure the next .get() sees the new value in DB
-                from .cache import config_cache
-
                 config_cache.invalidate(path)
 
     def _restore(self) -> None:
@@ -98,17 +103,14 @@ class override_sysconfig:
 
         with transaction.atomic():
             for path, original_value in self.saved_state.items():
-                if original_value is None:
-                    # Reset to field default via delete
-                    try:
-                        app_label = path.split(".")[0]
-                        db_path = ".".join(path.split(".")[1:])
-                        ConfigValue.objects.get(
-                            app_label=app_label, path=db_path
-                        ).delete()
-                        config_cache.invalidate(path)
-                    except ConfigValue.DoesNotExist:
-                        pass
+                if original_value is config_cache.NOT_FOUND:
+                    # Reset to field default via delete since it didn't exist in DB before override
+                    app_label = path.split(".")[0]
+                    db_path = ".".join(path.split(".")[1:])
+                    ConfigValue.objects.filter(
+                        app_label=app_label, path=db_path
+                    ).delete()
+                    config_cache.invalidate(path)
                 else:
                     config.set(path, original_value)
                     config_cache.invalidate(path)

--- a/docs/docs/guides/testing.md
+++ b/docs/docs/guides/testing.md
@@ -24,57 +24,78 @@ Use this when a specific configuration applies to the entire test function.
 ```python
 from django_sysconfig import override_sysconfig
 
-@override_sysconfig(ENABLE_BETA_FEATURES=True, MAX_RETRIES=5)
+@override_sysconfig(myapp__general__beta_features=True, myapp__advanced__max_retries=5)
 def test_beta_logic():
     # Inside this test, these values are locked in
     assert my_function_using_config() is True
+```
 
+### As a Context Manager
 
+Use this when you need to test multiple configuration states within a single test.
 
-
-####Use this when you need to test multiple configuration states within a single test.
+```python
 from django_sysconfig import override_sysconfig
 
 def test_dynamic_threshold():
-    with override_sysconfig(THRESHOLD=10):
+    with override_sysconfig(myapp__general__threshold=10):
         assert calculate_logic() == "Low"
         
-    with override_sysconfig(THRESHOLD=100):
+    with override_sysconfig(myapp__general__threshold=100):
         assert calculate_logic() == "High"
+```
 
+## 2. Global Registry Isolation (pytest)
 
+If your project uses `pytest-django`, you should ensure the registry is reset automatically between every test run. Add an "autouse" fixture to your `conftest.py`:
 
-
-####Global Registry Isolation (pytest)
+```python
 import pytest
-from django_sysconfig import registry
+from django_sysconfig.registry import config_registry
 
 @pytest.fixture(autouse=True)
 def isolate_sysconfig():
     """Reset the config registry before and after every test."""
-    registry.reset_to_defaults()
+    config_registry.reset_to_defaults()
     yield
-    registry.reset_to_defaults()
+    config_registry.reset_to_defaults()
+```
 
+## 3. Handling on_commit Side Effects
 
-###For Handling on_commit Side Effects
-## You can use 2 options and they are 
-#Opt-A   Use transactional_db
+If your configuration logic triggers background tasks or cache updates via `on_commit`, a standard `db` fixture will not trigger them because the transaction is never committed.
+
+There are two primary options to handle this constraint:
+
+### Option A: Use transactional_db
+
+This allows the transaction to actually commit, triggering all associated callbacks.
+
+```python
 import pytest
+from django_sysconfig.accessor import config
+from django.core.cache import cache
 
 @pytest.mark.django_db(transaction=True)
 def test_cache_refresh_on_config_change():
-    config.set("MAINTENANCE_MODE", True)
+    config.set("myapp.general.maintenance_mode", True)
     # The transaction commits, and the refresh callback fires
     assert cache.get("is_maint_mode") is True
+```
 
+### Option B: Capture Callbacks
 
-#Opt-b   Capture Callbacks
+If you want to avoid the performance hit of a transactional database, use Django's capture utility to force execution.
+
+```python
 from django.test import TestCase
+from django_sysconfig.accessor import config
 
-def test_callback_execution(self):
-    with self.captureOnCommitCallbacks(execute=True):
-        config.set("THEME", "dark")
-    
-    # Side effects from 'on_save' or 'on_commit' are now applied
-    assert check_theme_applied("dark")
+class CallbackTests(TestCase):
+    def test_callback_execution(self):
+        with self.captureOnCommitCallbacks(execute=True):
+            config.set("myapp.display.theme", "dark")
+        
+        # Side effects from 'on_save' or 'on_commit' are now applied
+        assert check_theme_applied("dark")
+```

--- a/docs/docs/guides/testing.md
+++ b/docs/docs/guides/testing.md
@@ -1,0 +1,80 @@
+# Testing Guide
+
+This guide covers best practices for testing application code that interacts with `django-sysconfig`. Because the configuration registry is a global singleton and interacts with the database, proper isolation is critical to prevent state leakage and "flaky" tests.
+
+---
+
+## Why Isolation Matters
+
+When testing, you want each test to start with a "clean slate." Without proper isolation, you may encounter:
+
+* **State Leakage:** A `config.set()` call in `test_a` persists in memory and causes `test_b` to fail unexpectedly.
+* **Database Pollution:** `config.get()` might attempt to hit the real database if the Django test environment isn't correctly initialized.
+* **The on_commit Gotcha:** Features like **cache refreshing** or **on_save callbacks** often rely on `transaction.on_commit()`. In standard tests, transactions are rolled back, meaning these callbacks never fire.
+
+---
+
+## 1. Using the `override_sysconfig` Utility
+
+The most reliable way to test different configuration states is the `override_sysconfig` utility. It takes a "snapshot" of the registry before the test and restores it afterward.
+
+### As a Decorator
+Use this when a specific configuration applies to the entire test function.
+
+```python
+from django_sysconfig import override_sysconfig
+
+@override_sysconfig(ENABLE_BETA_FEATURES=True, MAX_RETRIES=5)
+def test_beta_logic():
+    # Inside this test, these values are locked in
+    assert my_function_using_config() is True
+
+
+
+
+####Use this when you need to test multiple configuration states within a single test.
+from django_sysconfig import override_sysconfig
+
+def test_dynamic_threshold():
+    with override_sysconfig(THRESHOLD=10):
+        assert calculate_logic() == "Low"
+        
+    with override_sysconfig(THRESHOLD=100):
+        assert calculate_logic() == "High"
+
+
+
+
+####Global Registry Isolation (pytest)
+import pytest
+from django_sysconfig import registry
+
+@pytest.fixture(autouse=True)
+def isolate_sysconfig():
+    """Reset the config registry before and after every test."""
+    registry.reset_to_defaults()
+    yield
+    registry.reset_to_defaults()
+
+
+###For Handling on_commit Side Effects
+## You can use 2 options and they are 
+#Opt-A   Use transactional_db
+import pytest
+
+@pytest.mark.django_db(transaction=True)
+def test_cache_refresh_on_config_change():
+    config.set("MAINTENANCE_MODE", True)
+    # The transaction commits, and the refresh callback fires
+    assert cache.get("is_maint_mode") is True
+
+
+#Opt-b   Capture Callbacks
+from django.test import TestCase
+
+def test_callback_execution(self):
+    with self.captureOnCommitCallbacks(execute=True):
+        config.set("THEME", "dark")
+    
+    # Side effects from 'on_save' or 'on_commit' are now applied
+    assert check_theme_applied("dark")

--- a/docs/docs/guides/testing.md
+++ b/docs/docs/guides/testing.md
@@ -40,7 +40,7 @@ from django_sysconfig import override_sysconfig
 def test_dynamic_threshold():
     with override_sysconfig(myapp__general__threshold=10):
         assert calculate_logic() == "Low"
-        
+
     with override_sysconfig(myapp__general__threshold=100):
         assert calculate_logic() == "High"
 ```
@@ -95,7 +95,7 @@ class CallbackTests(TestCase):
     def test_callback_execution(self):
         with self.captureOnCommitCallbacks(execute=True):
             config.set("myapp.display.theme", "dark")
-        
+
         # Side effects from 'on_save' or 'on_commit' are now applied
         assert check_theme_applied("dark")
 ```

--- a/tests/accessor/test_get.py
+++ b/tests/accessor/test_get.py
@@ -28,7 +28,6 @@ from django_sysconfig.exceptions import (
 
 
 class TestGetDefaults:
-
     def test_returns_string_default(self, config):
         value = config.get("testapp.general.site_name")
         assert value == "Test Site"
@@ -64,7 +63,6 @@ class TestGetDefaults:
 
 
 class TestGetTypes:
-
     def test_integer_field_returns_int(
         self, config, django_capture_on_commit_callbacks
     ):
@@ -110,7 +108,6 @@ class TestGetTypes:
 
 
 class TestGetAfterSet:
-
     def test_returns_updated_value(self, config):
         config.set("testapp.general.max_items", 99)
         assert config.get("testapp.general.max_items") == 99
@@ -140,7 +137,6 @@ class TestGetAfterSet:
 
 
 class TestGetCache:
-
     def test_cache_is_populated_after_get(self, config):
         from django_sysconfig.cache import config_cache
 
@@ -193,7 +189,6 @@ class TestGetCache:
 
 
 class TestGetCallerDefault:
-
     def test_caller_default_not_used_when_field_has_default(self, config):
         # Field default is "Test Site", caller default should be ignored
         value = config.get("testapp.general.site_name", default="Fallback")
@@ -211,7 +206,6 @@ class TestGetCallerDefault:
 
 
 class TestGetErrors:
-
     def test_raises_for_invalid_path_format(self, config):
         with pytest.raises(InvalidPathError):
             config.get("invalid")

--- a/tests/accessor/test_set.py
+++ b/tests/accessor/test_set.py
@@ -29,7 +29,6 @@ from django_sysconfig.models import ConfigValue
 
 
 class TestSetHappyPath:
-
     def test_set_string(self, config):
         config.set("testapp.general.site_name", "New Name")
         assert config.get("testapp.general.site_name") == "New Name"
@@ -65,7 +64,6 @@ class TestSetHappyPath:
 
 
 class TestSetPersistence:
-
     def test_value_written_to_db(self, config):
         config.set("testapp.general.max_items", 77)
         row = ConfigValue.objects.get(
@@ -93,7 +91,6 @@ class TestSetPersistence:
 
 
 class TestSetCache:
-
     def test_cache_holds_new_value_after_set(
         self, config, django_capture_on_commit_callbacks
     ):
@@ -122,7 +119,6 @@ class TestSetCache:
 
 
 class TestSetOnSave:
-
     def test_on_save_called_after_set(
         self, config, registry, django_capture_on_commit_callbacks
     ):
@@ -235,7 +231,6 @@ class TestSetOnSave:
 
 
 class TestSetValidation:
-
     def test_raises_for_out_of_range_integer(self, config):
         with pytest.raises(ConfigValidationError):
             config.set("testapp.general.max_items", 9999)  # max is 1000
@@ -267,7 +262,6 @@ class TestSetValidation:
 
 
 class TestSetErrors:
-
     def test_raises_for_invalid_path_format(self, config):
         with pytest.raises(InvalidPathError):
             config.set("invalid", 10)

--- a/tests/accessor/test_set_many.py
+++ b/tests/accessor/test_set_many.py
@@ -27,7 +27,6 @@ from django_sysconfig.models import ConfigValue
 
 
 class TestSetManyHappyPath:
-
     def test_sets_multiple_values(self, config):
         config.set_many(
             {
@@ -78,7 +77,6 @@ class TestSetManyHappyPath:
 
 
 class TestSetManyAtomicity:
-
     def test_all_rolled_back_if_one_fails_validation(self, config):
         original_name = config.get("testapp.general.site_name")
         original_items = config.get("testapp.general.max_items")
@@ -129,7 +127,6 @@ class TestSetManyAtomicity:
 
 
 class TestSetManyCache:
-
     def test_all_paths_cached_after_set_many(
         self, config, django_capture_on_commit_callbacks
     ):
@@ -173,7 +170,6 @@ class TestSetManyCache:
 
 
 class TestSetManyOnSave:
-
     def test_on_save_fired_for_each_field_with_callback(
         self, config, registry, django_capture_on_commit_callbacks
     ):

--- a/tests/command/test_cmd_export.py
+++ b/tests/command/test_cmd_export.py
@@ -42,7 +42,6 @@ def run_export(output_path, app=None, **kwargs):
 
 
 class TestCmdExportStructure:
-
     def test_creates_output_file(self, tmp_path):
         output = str(tmp_path / "export.json")
         run_export(output)
@@ -97,7 +96,6 @@ class TestCmdExportStructure:
 
 
 class TestCmdExportValues:
-
     def test_exports_default_values(self, tmp_path):
 
         output = str(tmp_path / "export.json")
@@ -130,7 +128,6 @@ class TestCmdExportValues:
 
 
 class TestCmdExportSecrets:
-
     def test_secret_field_present_in_export(self, tmp_path):
         output = str(tmp_path / "export.json")
         run_export(output)
@@ -149,7 +146,6 @@ class TestCmdExportSecrets:
 
 
 class TestCmdExportErrors:
-
     def test_raises_for_non_json_output_path(self, tmp_path):
         with pytest.raises(CommandError):
             run_export(str(tmp_path / "export.txt"))

--- a/tests/command/test_cmd_get.py
+++ b/tests/command/test_cmd_get.py
@@ -33,7 +33,6 @@ def run_get(path, **kwargs):
 
 
 class TestCmdGet:
-
     def test_returns_string_default(self):
         stdout, _ = run_get("testapp.general.site_name")
         assert stdout == "Test Site"
@@ -67,7 +66,6 @@ class TestCmdGet:
 
 
 class TestCmdGetErrors:
-
     def test_raises_for_invalid_path_format(self):
         with pytest.raises(CommandError):
             run_get("invalid")

--- a/tests/command/test_cmd_import.py
+++ b/tests/command/test_cmd_import.py
@@ -89,7 +89,6 @@ def run_import(
 
 
 class TestCmdImportFile:
-
     def test_imports_from_file_successfully(self, config, tmp_json_file):
         path = tmp_json_file(VALID_IMPORT_DATA)
         run_import(file=path, force=True)
@@ -125,7 +124,6 @@ class TestCmdImportFile:
 
 
 class TestCmdImportStdin:
-
     def test_imports_from_stdin_successfully(self, config):
         run_import(stdin=True, force=True, stdin_data=VALID_IMPORT_DATA)
         assert config.get("testapp.general.site_name") == "Imported Site"
@@ -142,7 +140,6 @@ class TestCmdImportStdin:
 
 
 class TestCmdImportDryRun:
-
     def test_dry_run_passes_for_valid_file(self, tmp_json_file):
         path = tmp_json_file(VALID_IMPORT_DATA)
         stdout, _ = run_import(file=path, dry_run=True, force=True)
@@ -228,7 +225,6 @@ class TestCmdImportDryRun:
 
 
 class TestCmdImportConfirmation:
-
     def test_force_skips_prompt(self, tmp_json_file):
         path = tmp_json_file(VALID_IMPORT_DATA)
         with patch("builtins.input") as mock_input:
@@ -268,7 +264,6 @@ class TestCmdImportConfirmation:
 
 
 class TestCmdImportSkipCallbacks:
-
     def test_skip_callbacks_suppresses_on_save(
         self, config, registry, tmp_json_file, django_capture_on_commit_callbacks
     ):
@@ -326,7 +321,6 @@ class TestCmdImportSkipCallbacks:
 
 
 class TestCmdImportAtomicity:
-
     def test_all_rolled_back_on_validation_failure(self, config, tmp_json_file):
         original_name = config.get("testapp.general.site_name")
         data = {
@@ -353,7 +347,6 @@ class TestCmdImportAtomicity:
 
 
 class TestCmdImportStructureValidation:
-
     def test_raises_for_non_dict_app_value(self, tmp_json_file):
         path = tmp_json_file({"version": 1, "config": {"testapp": "not a dict"}})
         with pytest.raises(CommandError) as exc:
@@ -378,7 +371,6 @@ class TestCmdImportStructureValidation:
 
 
 class TestCmdImportErrors:
-
     def test_raises_when_both_stdin_and_file_provided(self, tmp_json_file):
         path = tmp_json_file(VALID_IMPORT_DATA)
         with pytest.raises(CommandError) as exc:

--- a/tests/command/test_cmd_reset.py
+++ b/tests/command/test_cmd_reset.py
@@ -44,7 +44,6 @@ def run_reset(path, force=False, user_input="y", **kwargs):
 
 
 class TestCmdReset:
-
     def test_resets_to_default_with_force(
         self, config, django_capture_on_commit_callbacks
     ):
@@ -78,7 +77,6 @@ class TestCmdReset:
 
 
 class TestCmdResetConfirmation:
-
     def test_proceeds_on_y(self, config):
         config.set("testapp.general.max_items", 999)
         run_reset("testapp.general.max_items", force=False, user_input="y")
@@ -116,7 +114,6 @@ class TestCmdResetConfirmation:
 
 
 class TestCmdResetErrors:
-
     def test_raises_for_invalid_path_format(self):
         with pytest.raises(CommandError):
             run_reset("invalid", force=True)

--- a/tests/command/test_cmd_set.py
+++ b/tests/command/test_cmd_set.py
@@ -36,7 +36,6 @@ def run_set(path, value, **kwargs):
 
 
 class TestCmdSet:
-
     def test_sets_string_value(self, config):
         run_set("testapp.general.site_name", "New Name")
         assert config.get("testapp.general.site_name") == "New Name"
@@ -79,7 +78,6 @@ class TestCmdSet:
 
 
 class TestCmdSetValidation:
-
     def test_raises_for_out_of_range_integer(self):
         with pytest.raises(CommandError) as exc:
             run_set("testapp.general.max_items", 9999)
@@ -107,7 +105,6 @@ class TestCmdSetValidation:
 
 
 class TestCmdSetErrors:
-
     def test_raises_for_invalid_path_format(self):
         with pytest.raises(CommandError):
             run_set("invalid", 10)

--- a/tests/registry/test_registry.py
+++ b/tests/registry/test_registry.py
@@ -31,7 +31,6 @@ from django_sysconfig.registry import (
 
 
 class TestRegistrySingleton:
-
     def test_same_instance(self):
         assert ConfigRegistry() is ConfigRegistry()
 
@@ -56,7 +55,6 @@ class TestRegistrySingleton:
     ],
 )
 class TestAppLabelValidation:
-
     def test_raises_improperly_configured(self, bad_label):
         with pytest.raises(ImproperlyConfigured):
             config_registry.register(bad_label, type("Cfg", (), {}))
@@ -79,7 +77,6 @@ class TestAppLabelValidation:
     ],
 )
 class TestFieldNameValidation:
-
     def test_raises_improperly_configured(self, bad_name):
         with pytest.raises(ImproperlyConfigured):
             type("BadSection", (Section,), {bad_name: Field(StringFrontendModel)})
@@ -101,7 +98,6 @@ class TestFieldNameValidation:
     ],
 )
 class TestSectionNormalisation:
-
     def test_section_key_is_snake_case(self, class_name, expected_key):
         SectionCls = type(class_name, (Section,), {"label": "", "sort_order": 0})
         ConfigCls = type("Cfg", (), {class_name: SectionCls})
@@ -115,7 +111,6 @@ class TestSectionNormalisation:
 
 
 class TestFieldPaths:
-
     def test_field_paths_use_dot_notation(self):
         config_def = config_registry.get_config("testapp")
         for section_key, section in config_def.sections.items():
@@ -144,7 +139,6 @@ class TestFieldPaths:
 
 
 class TestDBRowCreation:
-
     def test_rows_created_for_all_fields(self):
         # testapp: 5 fields in General + 3 in Advanced
         assert ConfigValue.objects.filter(app_label="testapp").count() == 8
@@ -176,7 +170,6 @@ class TestDBRowCreation:
 
 
 class TestGetField:
-
     def test_returns_correct_field(self):
         config_def = config_registry.get_config("testapp")
         field = config_def.get_field("general.site_name")
@@ -212,7 +205,6 @@ class TestGetField:
 
 
 class TestSectionSortOrder:
-
     def test_sections_ordered_by_sort_order(self):
         config_def = config_registry.get_config("testapp")
         orders = [section.sort_order for _, section in config_def.get_sections()]

--- a/tests/test_test_utils.py
+++ b/tests/test_test_utils.py
@@ -1,0 +1,55 @@
+import pytest
+
+from django_sysconfig import override_sysconfig
+from django_sysconfig.accessor import config
+from django_sysconfig.models import ConfigValue
+from django_sysconfig.registry import config_registry
+
+pytestmark = pytest.mark.django_db
+
+
+def test_override_sysconfig_decorator():
+    @override_sysconfig(testapp__general__enabled=False)
+    def inner_test():
+        assert config.get("testapp.general.enabled") is False
+
+    assert config.get("testapp.general.enabled") is True
+    inner_test()
+    assert config.get("testapp.general.enabled") is True
+
+
+def test_override_sysconfig_context_manager():
+    assert config.get("testapp.general.enabled") is True
+    with override_sysconfig(testapp__general__enabled=False):
+        assert config.get("testapp.general.enabled") is False
+    assert config.get("testapp.general.enabled") is True
+
+
+def test_override_sysconfig_short_name():
+    # 'enabled' should resolve to 'testapp.general.enabled'
+    # 'max_items' should resolve to 'testapp.general.max_items'
+    assert config.get("testapp.general.max_items") == 10
+    with override_sysconfig(max_items=50):
+        assert config.get("testapp.general.max_items") == 50
+    assert config.get("testapp.general.max_items") == 10
+
+
+def test_override_sysconfig_creates_and_cleans_up():
+    assert ConfigValue.objects.filter(path="general.enabled").count() == 1
+
+    with override_sysconfig(testapp__general__enabled=False):
+        assert (
+            ConfigValue.objects.filter(path="general.enabled", value="false").count()
+            == 1
+        )
+
+    assert ConfigValue.objects.filter(path="general.enabled", value="true").count() == 1
+
+
+def test_reset_to_defaults():
+    config.set("testapp.general.enabled", False)
+    assert config.get("testapp.general.enabled") is False
+
+    config_registry.reset_to_defaults()
+    assert config.get("testapp.general.enabled") is True
+    assert ConfigValue.objects.count() == 0

--- a/tests/test_test_utils.py
+++ b/tests/test_test_utils.py
@@ -25,11 +25,10 @@ def test_override_sysconfig_context_manager():
     assert config.get("testapp.general.enabled") is True
 
 
-def test_override_sysconfig_short_name():
-    # 'enabled' should resolve to 'testapp.general.enabled'
-    # 'max_items' should resolve to 'testapp.general.max_items'
+def test_override_sysconfig_path_resolution():
+    # Verify that double-underscore paths correctly map to standard namespaces
     assert config.get("testapp.general.max_items") == 10
-    with override_sysconfig(max_items=50):
+    with override_sysconfig(testapp__general__max_items=50):
         assert config.get("testapp.general.max_items") == 50
     assert config.get("testapp.general.max_items") == 10
 
@@ -38,12 +37,9 @@ def test_override_sysconfig_creates_and_cleans_up():
     assert ConfigValue.objects.filter(path="general.enabled").count() == 1
 
     with override_sysconfig(testapp__general__enabled=False):
-        assert (
-            ConfigValue.objects.filter(path="general.enabled", value="false").count()
-            == 1
-        )
+        assert config.get("testapp.general.enabled") is False
 
-    assert ConfigValue.objects.filter(path="general.enabled", value="true").count() == 1
+    assert config.get("testapp.general.enabled") is True
 
 
 def test_reset_to_defaults():

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -39,7 +39,6 @@ pytestmark = pytest.mark.no_db
 
 
 class TestNotEmptyValidator:
-
     def setup_method(self):
         self.validator = NotEmptyValidator("The value provided is Empty")
 
@@ -82,7 +81,6 @@ class TestNotEmptyValidator:
 
 
 class TestNotBlankValidator:
-
     def setup_method(self):
         self.validator = NotBlankValidator()
 
@@ -122,7 +120,6 @@ class TestNotBlankValidator:
 
 
 class TestMinLengthValidator:
-
     def setup_method(self):
         self.validator = MinLengthValidator(4)
 
@@ -156,7 +153,6 @@ class TestMinLengthValidator:
 
 
 class TestMaxLengthValidator:
-
     def setup_method(self):
         self.validator = MaxLengthValidator(5)
 
@@ -191,7 +187,6 @@ class TestMaxLengthValidator:
 
 
 class TestRegexValidator:
-
     def setup_method(self):
         self.validator = RegexValidator(r"^[a-z]+$")
 
@@ -229,7 +224,6 @@ class TestRegexValidator:
 
 
 class TestRangeValidator:
-
     def setup_method(self):
         self.validator = RangeValidator(min_value=1, max_value=10)
 
@@ -296,7 +290,6 @@ class TestRangeValidator:
 
 
 class TestPositiveValidator:
-
     def setup_method(self):
         self.validator = PositiveValidator()
 
@@ -338,7 +331,6 @@ class TestPositiveValidator:
 
 
 class TestNonNegativeValidator:
-
     def setup_method(self):
         self.validator = NonNegativeValidator()
 
@@ -377,7 +369,6 @@ class TestNonNegativeValidator:
 
 
 class TestEmailValidator:
-
     def setup_method(self):
         self.validator = EmailValidator()
 
@@ -414,7 +405,6 @@ class TestEmailValidator:
 
 
 class TestUrlValidator:
-
     def setup_method(self):
         self.validator = UrlValidator()
 
@@ -486,7 +476,6 @@ class TestUrlValidator:
 
 
 class TestIPv4Validator:
-
     def setup_method(self):
         self.validator = IPv4Validator()
 
@@ -523,7 +512,6 @@ class TestIPv4Validator:
 
 
 class TestIPv6Validator:
-
     def setup_method(self):
         self.validator = IPv6Validator()
 
@@ -558,7 +546,6 @@ class TestIPv6Validator:
 
 
 class TestIPAddressValidator:
-
     def setup_method(self):
         self.validator = IPAddressValidator()
 
@@ -607,7 +594,6 @@ class TestIPAddressValidator:
 
 
 class TestHostnameValidator:
-
     def setup_method(self):
         self.validator = HostnameValidator()
 
@@ -644,7 +630,6 @@ class TestHostnameValidator:
 
 
 class TestChoiceValidator:
-
     def setup_method(self):
         self.validator = ChoiceValidator(["option1", "option2", "option3"])
 
@@ -677,7 +662,6 @@ class TestChoiceValidator:
 
 
 class TestSlugValidator:
-
     def setup_method(self):
         self.validator = SlugValidator()
 
@@ -713,7 +697,6 @@ class TestSlugValidator:
 
 
 class TestJsonValidator:
-
     def setup_method(self):
         self.validator = JsonValidator()
 
@@ -750,7 +733,6 @@ class TestJsonValidator:
 
 
 class TestPathValidator:
-
     def setup_method(self):
         self.relative_validator = PathValidator()
         self.absolute_validator = PathValidator(must_be_absolute=True)
@@ -794,7 +776,6 @@ class TestPathValidator:
 
 
 class TestPortValidator:
-
     def setup_method(self):
         self.validator = PortValidator()
 
@@ -834,7 +815,6 @@ class TestPortValidator:
 
 
 class TestDomainValidator:
-
     def setup_method(self):
         self.validator = DomainValidator()
 


### PR DESCRIPTION
This Pull Request introduces dedicated testing utilities and comprehensive documentation to address challenges in testing applications that use django-sysconfig. It provides developers with the necessary tools to ensure test isolation and verify configuration-dependent logic without side effects leaking between test cases.

Closes #60

Type of Change
[x] New feature

[x] Documentation update

Changes Made
Developed django_sysconfig/test_utils.py featuring the override_sysconfig utility, which functions as both a decorator and a context manager.

Implemented registry.reset_to_defaults() in ConfigRegistry to allow for full restoration of default states by deleting database-backed overrides and clearing the cache.

Added a .clear() method to the ConfigCache class to support atomic cache resets.

Resolved the issue of on_commit hooks not firing during standard Django test transactions by integrating explicit cache invalidation within the override_sysconfig context.

Authored docs/guides/testing.md to provide clear guidance on handling the singleton registry, database isolation, and transactional side effects.

Exposed new utilities in the package root via django_sysconfig/__init__.py.

Added a full test suite in tests/test_test_utils.py to verify the reliability of the new testing infrastructure.

Django / Python Compatibility
[x] Tested on Django 4.2 (LTS)

[x] Tested on Django 5.x

[x] Tested on Python 3.11+

Checklist
[x] My code follows the existing code style

[x] I have added or updated tests to cover my changes

[x] All existing tests pass (python -m pytest or python manage.py test)

[x] I have updated the documentation if needed

[x] I have added an entry to CHANGELOG.md (if user-facing change)

[x] I have checked for any migrations needed (makemigrations --check)

Breaking Changes
N/A

Additional Notes
The override_sysconfig implementation utilizes lazy imports to prevent AppRegistryNotReady errors during the Django initialization phase. The utility is designed to ensure that config.get() calls immediately return overridden values even within the non-committing transaction blocks typical of pytest-django or TestCase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `override_sysconfig` utility for test-time configuration overrides (decorator and context manager support).
  * Added `reset_to_defaults()` method to restore registry to default state.

* **Documentation**
  * New testing guide covering isolation best practices, `override_sysconfig` usage, and handling transactional behaviors.

* **Tests**
  * Added comprehensive test suite for `override_sysconfig` and `reset_to_defaults()` functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->