### PR TITLE
chore: Add python 3.10 & 3.14 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
-        django-version: ["4.2", "5.1", "5.2"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        django-version: ["4.2", "5.2", "6.0"]
+        exclude:
+          # Django 4.2 doesn't support Python 3.13+
+          - django-version: "4.2"
+            python-version: "3.13"
+          - django-version: "4.2"
+            python-version: "3.14"
+          # Django 6.0 doesn't support Python 3.10, 3.11
+          - django-version: "6.0"
+            python-version: "3.10"
+          - django-version: "6.0"
+            python-version: "3.11"
 
     steps:
       - uses: actions/checkout@v4

--- a/django_sysconfig/cache.py
+++ b/django_sysconfig/cache.py
@@ -1,4 +1,4 @@
-from typing import Any, Self
+from typing import Any
 
 from django.core.cache import cache
 
@@ -9,9 +9,9 @@ class ConfigCache:
     # Made a class attribute for public access
     NOT_FOUND = object()
 
-    _instance: Self | None = None
+    _instance: "ConfigCache | None" = None
 
-    def __new__(cls) -> Self:
+    def __new__(cls) -> "ConfigCache":
         if cls._instance is None:
             cls._instance = super().__new__(cls)
         return cls._instance

--- a/django_sysconfig/management/commands/config.py
+++ b/django_sysconfig/management/commands/config.py
@@ -1,7 +1,7 @@
 import json
 import os
 import sys
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from decimal import Decimal
 
 from django.core.management.base import BaseCommand, CommandError, CommandParser
@@ -10,7 +10,7 @@ from django_sysconfig.accessor import config
 from django_sysconfig.exceptions import ConfigError, ConfigValidationError
 from django_sysconfig.registry import config_registry
 
-UTC = UTC
+UTC = timezone.utc
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/django_sysconfig/management/commands/config.py
+++ b/django_sysconfig/management/commands/config.py
@@ -10,6 +10,8 @@ from django_sysconfig.accessor import config
 from django_sysconfig.exceptions import ConfigError, ConfigValidationError
 from django_sysconfig.registry import config_registry
 
+UTC = UTC
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -33,7 +33,7 @@ Want the full picture first? Read the [Introduction](/introduction) to understan
 
 | Dependency     | Minimum version |
 | -------------- | --------------- |
-| Python         | 3.11            |
+| Python         | 3.10            |
 | Django         | 4.2             |
 | `cryptography` | 41.0            |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,20 +15,21 @@ classifiers = [
     "Environment :: Web Environment",
     "Framework :: Django",
     "Framework :: Django :: 4.2",
-    "Framework :: Django :: 5.0",
-    "Framework :: Django :: 5.1",
     "Framework :: Django :: 5.2",
+    "Framework :: Django :: 6.0",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Internet :: WWW/HTTP",
     "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 dependencies = [
     "django>=4.2",
     "cryptography>=41.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,11 +75,11 @@ markers = [
 
 [tool.black]
 line-length = 88
-target-version = ["py311"]
+target-version = ["py310"]
 
 [tool.ruff]
 line-length = 88
-target-version = "py311"
+target-version = "py310"
 
 [tool.ruff.lint]
 select = ["E", "W", "F", "I", "B", "C4", "UP"]


### PR DESCRIPTION
## Description
Add python 3.10 & 3.14 support for our django app.

---

## Type of Change

- [X] 🔧 Chore
- [X] 🔧 Refactor (no behaviour change)
- [X] 🧪 Tests only

---

## Changes Made

Include python versions 3.10, 3.14 in `pyproject.toml` & update test matix in `ci.yml`.

---

## Django / Python Compatibility

<!-- Confirm which versions this has been tested against, or note if untested -->

- [X] Tested on Django 4.2 (LTS)
- [X] Tested on Django 5.x
- [X] Tested on Python 3.10+

---

## Checklist

- [X] My code follows the existing code style
- [X] I have added or updated tests to cover my changes
- [X] All existing tests pass (`python -m pytest` or `python manage.py test`)
- [X] I have updated the documentation if needed

---

## Breaking Changes

N/A

---

## Additional Notes

We should check for any references for minimum required version and update those too.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Lowered minimum Python requirement to 3.10 and updated project metadata.
  * Added Django 6.0 support; removed Django 5.0/5.1.

* **Tests**
  * CI now tests Python 3.10–3.14 and avoids unsupported Django/Python combinations.

* **Documentation**
  * Requirements updated to reflect Python 3.10 minimum.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->