### PR TITLE
fix: let exists raise for malformed paths

### DIFF
--- a/django_sysconfig/accessor.py
+++ b/django_sysconfig/accessor.py
@@ -380,14 +380,14 @@ class ConfigAccessor:
         Returns:
             True if the field is registered, False otherwise
         """
-        try:
-            app_label, section, field_name = self._parse_path(path)
+        app_label, section, field_name = self._parse_path(path)
 
+        try:
             # This ensures the config exists in the registry singleton object
             self._get_field(app_label, section, field_name)
 
             return True
-        except (InvalidPathError, AppNotFoundError, FieldNotFoundError):
+        except (AppNotFoundError, FieldNotFoundError):
             return False
 
     def is_set(self, path: str) -> bool:

--- a/tests/accessor/test_rest.py
+++ b/tests/accessor/test_rest.py
@@ -20,7 +20,8 @@ from django_sysconfig.exceptions import AppNotFoundError, InvalidPathError
 class TestExists:
     """
     exists() returns True if the path is registered in the schema,
-    False otherwise. It never raises — all exceptions are swallowed.
+    False if the app or field is not registered, and raises for malformed
+    paths so programmer errors are not hidden.
     """
 
     def test_returns_true_for_registered_field(self, config):
@@ -49,23 +50,23 @@ class TestExists:
     def test_returns_false_for_unknown_app(self, config):
         assert config.exists("unknown_app.general.site_name") is False
 
-    def test_returns_false_for_invalid_path_format(self, config):
-        assert config.exists("invalid") is False
+    def test_raises_for_invalid_path_format(self, config):
+        with pytest.raises(InvalidPathError):
+            config.exists("invalid")
 
-    def test_returns_false_for_two_part_path(self, config):
-        assert config.exists("testapp.general") is False
+    def test_raises_for_two_part_path(self, config):
+        with pytest.raises(InvalidPathError):
+            config.exists("testapp.general")
 
-    def test_returns_false_for_empty_string(self, config):
-        assert config.exists("") is False
+    def test_raises_for_empty_string(self, config):
+        with pytest.raises(InvalidPathError):
+            config.exists("")
 
-    def test_does_not_raise_for_any_bad_path(self, config):
-        # exists() must never raise, regardless of input
-        bad_paths = ["", "x", "x.y", "x.y.z.w", "...", "testapp..field"]
+    def test_raises_for_malformed_paths(self, config):
+        bad_paths = ["", "x", "x.y", "x.y.z.w"]
         for path in bad_paths:
-            try:
+            with pytest.raises(InvalidPathError):
                 config.exists(path)
-            except Exception as e:
-                pytest.fail(f"exists({path!r}) raised unexpectedly: {e}")
 
 
 # ===========================================================================
@@ -83,8 +84,9 @@ class TestIsSet:
         config.set("testapp.general.max_items", 50)
         assert config.is_set("testapp.general.max_items") is True
 
-    def test_returns_false_for_invalid_path(self, config):
-        assert config.is_set("invalid") is False
+    def test_raises_for_invalid_path(self, config):
+        with pytest.raises(InvalidPathError):
+            config.is_set("invalid")
 
     def test_returns_false_for_unknown_field(self, config):
         assert config.is_set("testapp.general.nonexistent") is False


### PR DESCRIPTION
## Summary
- Let `ConfigAccessor.exists()` propagate `InvalidPathError` for malformed path strings.
- Keep unknown apps/fields as false so normal existence checks still work.
- Update accessor tests for `exists()` and `is_set()` behavior.

Fixes #71.

## Validation
- `uv run --extra dev pytest -q`
