### PR TITLE
Fix: config.exists() now raises InvalidPathError for malformed paths

### DIFF
--- a/django_sysconfig/accessor.py
+++ b/django_sysconfig/accessor.py
@@ -379,6 +379,9 @@ class ConfigAccessor:
 
         Returns:
             True if the field is registered, False otherwise
+
+        Raises:
+            InvalidPathError: If path format is invalid (wrong number of segments)
         """
         try:
             app_label, section, field_name = self._parse_path(path)
@@ -387,7 +390,7 @@ class ConfigAccessor:
             self._get_field(app_label, section, field_name)
 
             return True
-        except (InvalidPathError, AppNotFoundError, FieldNotFoundError):
+        except (AppNotFoundError, FieldNotFoundError):
             return False
 
     def is_set(self, path: str) -> bool:
@@ -399,6 +402,9 @@ class ConfigAccessor:
 
         Returns:
             True if value exists in database with a non-empty value, False if using default
+
+        Raises:
+            InvalidPathError: If path format is invalid (wrong number of segments)
         """
         if not self.exists(path):
             return False

--- a/tests/accessor/test_rest.py
+++ b/tests/accessor/test_rest.py
@@ -20,7 +20,9 @@ from django_sysconfig.exceptions import AppNotFoundError, InvalidPathError
 class TestExists:
     """
     exists() returns True if the path is registered in the schema,
-    False otherwise. It never raises — all exceptions are swallowed.
+    False for unregistered apps/fields. InvalidPathError is raised
+    for malformed paths (wrong number of segments) so callers can
+    detect programmer errors early.
     """
 
     def test_returns_true_for_registered_field(self, config):
@@ -49,23 +51,23 @@ class TestExists:
     def test_returns_false_for_unknown_app(self, config):
         assert config.exists("unknown_app.general.site_name") is False
 
-    def test_returns_false_for_invalid_path_format(self, config):
-        assert config.exists("invalid") is False
+    def test_raises_for_invalid_path_format(self, config):
+        with pytest.raises(InvalidPathError):
+            config.exists("invalid")
 
-    def test_returns_false_for_two_part_path(self, config):
-        assert config.exists("testapp.general") is False
+    def test_raises_for_two_part_path(self, config):
+        with pytest.raises(InvalidPathError):
+            config.exists("testapp.general")
 
-    def test_returns_false_for_empty_string(self, config):
-        assert config.exists("") is False
+    def test_raises_for_empty_string(self, config):
+        with pytest.raises(InvalidPathError):
+            config.exists("")
 
-    def test_does_not_raise_for_any_bad_path(self, config):
-        # exists() must never raise, regardless of input
-        bad_paths = ["", "x", "x.y", "x.y.z.w", "...", "testapp..field"]
+    def test_raises_invalid_path_error_for_bad_paths(self, config):
+        bad_paths = ["", "x", "x.y", "x.y.z.w", "..."]
         for path in bad_paths:
-            try:
+            with pytest.raises(InvalidPathError):
                 config.exists(path)
-            except Exception as e:
-                pytest.fail(f"exists({path!r}) raised unexpectedly: {e}")
 
 
 # ===========================================================================
@@ -83,8 +85,9 @@ class TestIsSet:
         config.set("testapp.general.max_items", 50)
         assert config.is_set("testapp.general.max_items") is True
 
-    def test_returns_false_for_invalid_path(self, config):
-        assert config.is_set("invalid") is False
+    def test_raises_for_invalid_path(self, config):
+        with pytest.raises(InvalidPathError):
+            config.is_set("invalid")
 
     def test_returns_false_for_unknown_field(self, config):
         assert config.is_set("testapp.general.nonexistent") is False


### PR DESCRIPTION
## Summary

- `ConfigAccessor.exists()` previously caught `InvalidPathError` alongside `AppNotFoundError` and `FieldNotFoundError`, returning `False` for all three
- This made it impossible to distinguish between a structurally invalid path (programmer error) and a path that simply isn't registered
- Now `InvalidPathError` propagates from `exists()`, consistent with how `get()` and `set()` handle malformed paths

## Changes

- Removed `InvalidPathError` from the `except` clause in `exists()` method (`django_sysconfig/accessor.py`)
- Updated tests in `tests/accessor/test_rest.py` to expect `InvalidPathError` for malformed paths instead of `False`

## Test plan

- [x] All 336 existing tests pass
- [x] Updated `TestExists` class to verify `InvalidPathError` is raised for bad path formats
- [x] Verified `exists()` still returns `False` for unknown apps/fields (not affected by this change)

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid path formats now properly raise exceptions instead of being silently ignored, improving error visibility and debugging.

* **Documentation**
  * Updated method documentation to clarify exception behavior for malformed paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->