### PR TITLE
feat: Add `--dry-run` flag for `config set` sub-command

### DIFF
--- a/django_sysconfig/management/commands/config.py
+++ b/django_sysconfig/management/commands/config.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 from decimal import Decimal
 
 from django.core.management.base import BaseCommand, CommandError, CommandParser
+from django.db import transaction
 
 from django_sysconfig.accessor import config
 from django_sysconfig.exceptions import ConfigError, ConfigValidationError
@@ -51,6 +52,11 @@ class Command(BaseCommand):
         set_parser = subparsers.add_parser("set", help="Set a configuration value")
         set_parser.add_argument("path", help="Config path in app.section.field format")
         set_parser.add_argument("value", help="Value to set")
+        set_parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Validate the input value without saving into database",
+        )
 
         # --- reset ---
         reset_parser = subparsers.add_parser(
@@ -141,14 +147,31 @@ class Command(BaseCommand):
         """Parse and persist a single config value."""
         path = options["path"]
         raw = options["value"]
+        dry_run = options["dry_run"]
 
         try:
             app_label, section, field_name = config._parse_path(path)
             field = config._get_field(app_label, section, field_name)
             parsed = field.get_frontend_model_instance().get_value(raw)
 
-            config.set(path, parsed)
-            self.stdout.write(self.style.SUCCESS(f"✔ {path} updated successfully"))
+            with transaction.atomic():
+                config.set(path, parsed)
+
+                if dry_run:
+                    self.stdout.write(
+                        self.style.SUCCESS(f"✔ Validation passed for '{path}'")
+                    )
+                    self.stdout.write(
+                        self.style.WARNING("Dry run — no values will be saved")
+                    )
+                    raise transaction.TransactionManagementError("dry-run rollback")
+                else:
+                    self.stdout.write(
+                        self.style.SUCCESS(f"✔ {path} updated successfully")
+                    )
+
+        except transaction.TransactionManagementError:
+            pass
 
         except ConfigValidationError as e:
             errors = "\n".join(f"  • {err}" for err in e.errors)
@@ -290,7 +313,6 @@ class Command(BaseCommand):
             # rolled back — this runs path resolution, frontend-model coercion,
             # serialization, and field validators, so a dry-run failure means the
             # real import would also fail.
-            from django.db import transaction
 
             errors = []
             try:

--- a/django_sysconfig/management/commands/config.py
+++ b/django_sysconfig/management/commands/config.py
@@ -164,14 +164,10 @@ class Command(BaseCommand):
                     self.stdout.write(
                         self.style.WARNING("Dry run — no values will be saved")
                     )
-                    raise transaction.TransactionManagementError("dry-run rollback")
-                else:
-                    self.stdout.write(
-                        self.style.SUCCESS(f"✔ {path} updated successfully")
-                    )
+                    transaction.set_rollback(True)
+                    return
 
-        except transaction.TransactionManagementError:
-            pass
+                self.stdout.write(self.style.SUCCESS(f"✔ {path} updated successfully"))
 
         except ConfigValidationError as e:
             errors = "\n".join(f"  • {err}" for err in e.errors)
@@ -318,9 +314,7 @@ class Command(BaseCommand):
             try:
                 with transaction.atomic():
                     config.set_many(dict(paths), skip_on_save_callbacks=True)
-                    raise transaction.TransactionManagementError("dry-run rollback")
-            except transaction.TransactionManagementError:
-                pass
+                    transaction.set_rollback(True)
             except (ConfigValidationError, ConfigError) as e:
                 errors.append(str(e))
 

--- a/docs/docs/cli/management-command.md
+++ b/docs/docs/cli/management-command.md
@@ -46,7 +46,7 @@ The value is printed as a string. The underlying Python type (int, bool, Decimal
 Set a single config value from the command line.
 
 ```bash
-python manage.py config set <path> <value>
+python manage.py config set <path> <value> [--dry-run]
 ```
 
 **Arguments**
@@ -55,6 +55,12 @@ python manage.py config set <path> <value>
 |---|---|
 | `path` | Config path in `app.section.field` format |
 | `value` | The value to set, as a string — parsed by the field's frontend model |
+
+**Flags**
+
+| Flag | Description |
+|---|---|
+| `--dry-run` | Validate value without writing anything to the database |
 
 **Examples**
 

--- a/tests/command/test_cmd_set.py
+++ b/tests/command/test_cmd_set.py
@@ -104,8 +104,9 @@ class TestCmdSetValidation:
 class TestCmdSetDryRun:
 
     def test_dry_run_doesnt_save(self, config):
-        run_set("testapp.general.max_items", 200, dry_run=True)
-        assert config.get("testapp.general.max_items") != 200
+        original = config.get("testapp.general.max_items")
+        run_set("testapp.general.max_items", original + 1, dry_run=True)
+        assert config.get("testapp.general.max_items") == original
 
     def test_dry_run_raises_invalid_path(self):
         with pytest.raises(CommandError):

--- a/tests/command/test_cmd_set.py
+++ b/tests/command/test_cmd_set.py
@@ -101,6 +101,23 @@ class TestCmdSetValidation:
         assert config.get("testapp.general.max_items") == original
 
 
+class TestCmdSetDryRun:
+
+    def test_dry_run_doesnt_save(self, config):
+        run_set("testapp.general.max_items", 200, dry_run=True)
+        assert config.get("testapp.general.max_items") != 200
+
+    def test_dry_run_raises_invalid_path(self):
+        with pytest.raises(CommandError):
+            run_set("invalid.path", 200)
+
+    def test_dry_run_raises_on_validation_fail(self):
+        with pytest.raises(CommandError):
+            run_set("testapp.general.site_name", "")
+        with pytest.raises(CommandError):
+            run_set("testapp.general.max_items", 1002)
+
+
 # ---------------------------------------------------------------------------
 # Error cases
 # ---------------------------------------------------------------------------

--- a/tests/command/test_cmd_set.py
+++ b/tests/command/test_cmd_set.py
@@ -109,13 +109,13 @@ class TestCmdSetDryRun:
 
     def test_dry_run_raises_invalid_path(self):
         with pytest.raises(CommandError):
-            run_set("invalid.path", 200)
+            run_set("invalid.path", 200, dry_run=True)
 
     def test_dry_run_raises_on_validation_fail(self):
         with pytest.raises(CommandError):
-            run_set("testapp.general.site_name", "")
+            run_set("testapp.general.site_name", "", dry_run=True)
         with pytest.raises(CommandError):
-            run_set("testapp.general.max_items", 1002)
+            run_set("testapp.general.max_items", 1002, dry_run=True)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description
Add `--dry-run` flag for the `config set` sub-command

---

## Type of Change

<!-- Check all that apply -->

- [X] ✨ New feature

---

## Django / Python Compatibility

<!-- Confirm which versions this has been tested against, or note if untested -->

- [X] Tested on Django 4.2 (LTS)
- [X] Tested on Django 5.x
- [X] Tested on Python 3.10+

---

## Checklist

- [X] My code follows the existing code style
- [x] I have added or updated tests to cover my changes
- [X] All existing tests pass (`python -m pytest` or `python manage.py test`)
- [x] I have updated the documentation if needed

---

## Breaking Changes

<!-- If this is a breaking change, describe what breaks and how users should migrate -->

N/A

---

## Additional Notes

<!-- Anything else reviewers should know? Screenshots, context, tradeoffs made? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The `config set` subcommand now supports a `--dry-run` flag to validate inputs and run through the save flow without persisting any changes.

* **Documentation**
  * CLI docs updated to document the `--dry-run` flag and its behavior for the `config set` command.

* **Tests**
  * Added tests covering `--dry-run` behavior, including no-write verification and validation/error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->