### PR TITLE
refactor(command): give each config subcommand its own SubCommand class

### DIFF
--- a/django_sysconfig/management/commands/_config/base.py
+++ b/django_sysconfig/management/commands/_config/base.py
@@ -1,0 +1,30 @@
+from abc import ABC, abstractmethod
+
+from django.core.management.base import BaseCommand, CommandParser
+
+
+class SubCommand(ABC):
+    """One ``config`` subcommand: its CLI flags and the code that reads them.
+
+    Keeping ``add_arguments`` and ``handle`` on the same class is the point of
+    this base: a flag is declared next to the code that consumes it, so the two
+    cannot drift apart across modules.
+
+    Instances are built once at import time and shared by every invocation, so
+    subclasses must stay stateless — anything per-run arrives as an argument.
+    """
+
+    name: str
+    help: str = ""
+
+    @abstractmethod
+    def add_arguments(self, parser: CommandParser) -> None:
+        """Declare this subcommand's positional arguments and flags."""
+
+    @abstractmethod
+    def handle(self, command: BaseCommand, **options) -> None:
+        """Run the subcommand.
+
+        ``command`` is the parent :class:`~django.core.management.base.BaseCommand`
+        and supplies ``stdout``, ``stderr`` and ``style``.
+        """

--- a/django_sysconfig/management/commands/_config/base.py
+++ b/django_sysconfig/management/commands/_config/base.py
@@ -6,26 +6,21 @@ from django.core.management.base import BaseCommand, CommandParser
 class SubCommand(ABC):
     """One ``config`` subcommand: its CLI flags and the code that reads them.
 
-    Keeping ``add_arguments`` and ``handle`` on the same class is the point of
-    this base: a flag is declared next to the code that consumes it, so the two
-    cannot drift apart across modules.
-
-    Instances are built once at import time and shared by every invocation, so
-    subclasses must stay stateless — anything per-run arrives as an argument.
+    Declaring a flag next to the code that reads it keeps the two from drifting
+    apart. Instances are created once at import time and shared across every
+    invocation, so subclasses must stay stateless.
     """
 
     name: str
     help: str = ""
 
+    def register(self, subparsers) -> None:
+        """Build this subcommand's parser and populate it."""
+        parser = subparsers.add_parser(self.name, help=self.help, description=self.help)
+        self.add_arguments(parser)
+
     def add_arguments(self, parser: CommandParser) -> None:  # noqa: B027
-        """Declare this subcommand's positional arguments and flags.
-
-        Optional — a subcommand may legitimately take no arguments at all.
-        Mirrors ``BaseCommand.add_arguments``, which is likewise a no-op.
-
-        The empty body is deliberate, so B027 (missing ``@abstractmethod``)
-        is silenced: that rule exists to catch a *forgotten* decorator.
-        """
+        """Declare this subcommand's positional arguments and flags."""
 
     @abstractmethod
     def handle(self, command: BaseCommand, **options) -> None:

--- a/django_sysconfig/management/commands/_config/base.py
+++ b/django_sysconfig/management/commands/_config/base.py
@@ -17,9 +17,15 @@ class SubCommand(ABC):
     name: str
     help: str = ""
 
-    @abstractmethod
-    def add_arguments(self, parser: CommandParser) -> None:
-        """Declare this subcommand's positional arguments and flags."""
+    def add_arguments(self, parser: CommandParser) -> None:  # noqa: B027
+        """Declare this subcommand's positional arguments and flags.
+
+        Optional — a subcommand may legitimately take no arguments at all.
+        Mirrors ``BaseCommand.add_arguments``, which is likewise a no-op.
+
+        The empty body is deliberate, so B027 (missing ``@abstractmethod``)
+        is silenced: that rule exists to catch a *forgotten* decorator.
+        """
 
     @abstractmethod
     def handle(self, command: BaseCommand, **options) -> None:

--- a/django_sysconfig/management/commands/_config/export.py
+++ b/django_sysconfig/management/commands/_config/export.py
@@ -7,56 +7,74 @@ from django.core.management.base import CommandError
 from django_sysconfig.accessor import config
 from django_sysconfig.registry import config_registry
 
+from .base import SubCommand
 from .common import JSONEncoder
 
 UTC = timezone.utc
 
 
-def handle_export(command, **options):
-    """Serialise all registered config values to a JSON file."""
-    # 1. Validate
-    output_path = os.path.abspath(options["output"])
-    target_app = options.get("app")
+class ExportCommand(SubCommand):
+    name = "export"
+    help = "Export configuration values to a JSON file"
 
-    if not output_path.endswith(".json"):
-        raise CommandError("Output file must have a .json extension")
-
-    # 2. Enumerate apps
-    apps = [target_app] if target_app else config_registry.get_registered_apps()
-    if not apps:
-        raise CommandError("No registered app configurations found")
-
-    for app_label in apps:
-        if not config_registry.get_config(app_label):
-            raise CommandError(f"No config registered for app '{app_label}'")
-
-    command.stdout.write(
-        f"Exporting config for {len(apps)} app(s). "
-        "This may take a moment for large configs."
-    )
-    command.stdout.write(f"Output will be written to: {output_path}\n")
-
-    # 3. Fetch & serialise via accessor
-    result = {
-        "version": 1,
-        "exported_at": datetime.now(UTC).isoformat(),
-        "config": {},
-    }
-
-    for app_label in apps:
-        result["config"][app_label] = config.all(app_label)
-        command.stdout.write(f"  {app_label} exported...")
-
-    # 4. Write — restricted to owner read/write only (secrets may be present)
-    if os.path.exists(output_path):
-        os.chmod(output_path, 0o600)
-    fd = os.open(output_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-    with os.fdopen(fd, "w") as f:
-        json.dump(result, f, indent=2, cls=JSONEncoder)
-
-    command.stdout.write(command.style.SUCCESS(f"\n✔ Export complete → {output_path}"))
-    command.stderr.write(
-        command.style.WARNING(
-            "⚠ This file contains plaintext secrets. Handle it with care."
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "app", nargs="?", help="App label to export (exports all apps if omitted)"
         )
-    )
+        parser.add_argument(
+            "--output",
+            "-o",
+            default="config_export.json",
+            help="Output file path (default: config_export.json)",
+        )
+
+    def handle(self, command, **options):
+        """Serialise all registered config values to a JSON file."""
+        # 1. Validate
+        output_path = os.path.abspath(options["output"])
+        target_app = options.get("app")
+
+        if not output_path.endswith(".json"):
+            raise CommandError("Output file must have a .json extension")
+
+        # 2. Enumerate apps
+        apps = [target_app] if target_app else config_registry.get_registered_apps()
+        if not apps:
+            raise CommandError("No registered app configurations found")
+
+        for app_label in apps:
+            if not config_registry.get_config(app_label):
+                raise CommandError(f"No config registered for app '{app_label}'")
+
+        command.stdout.write(
+            f"Exporting config for {len(apps)} app(s). "
+            "This may take a moment for large configs."
+        )
+        command.stdout.write(f"Output will be written to: {output_path}\n")
+
+        # 3. Fetch & serialise via accessor
+        result = {
+            "version": 1,
+            "exported_at": datetime.now(UTC).isoformat(),
+            "config": {},
+        }
+
+        for app_label in apps:
+            result["config"][app_label] = config.all(app_label)
+            command.stdout.write(f"  {app_label} exported...")
+
+        # 4. Write — restricted to owner read/write only (secrets may be present)
+        if os.path.exists(output_path):
+            os.chmod(output_path, 0o600)
+        fd = os.open(output_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w") as f:
+            json.dump(result, f, indent=2, cls=JSONEncoder)
+
+        command.stdout.write(
+            command.style.SUCCESS(f"\n✔ Export complete → {output_path}")
+        )
+        command.stderr.write(
+            command.style.WARNING(
+                "⚠ This file contains plaintext secrets. Handle it with care."
+            )
+        )

--- a/django_sysconfig/management/commands/_config/get.py
+++ b/django_sysconfig/management/commands/_config/get.py
@@ -2,13 +2,22 @@ from django.core.management.base import CommandError
 
 from django_sysconfig import ConfigError, config
 
+from .base import SubCommand
 
-def handle_get(command, **options):
-    """Print the current value of a single config path."""
-    path = options["path"]
 
-    try:
-        value = config.get(path)
-        command.stdout.write(str(value))
-    except ConfigError as e:
-        raise CommandError(str(e)) from e
+class GetCommand(SubCommand):
+    name = "get"
+    help = "Get a configuration value"
+
+    def add_arguments(self, parser):
+        parser.add_argument("path", help="Config path in app.section.field format")
+
+    def handle(self, command, **options):
+        """Print the current value of a single config path."""
+        path = options["path"]
+
+        try:
+            value = config.get(path)
+            command.stdout.write(str(value))
+        except ConfigError as e:
+            raise CommandError(str(e)) from e

--- a/django_sysconfig/management/commands/_config/get.py
+++ b/django_sysconfig/management/commands/_config/get.py
@@ -1,6 +1,7 @@
 from django.core.management.base import CommandError
 
-from django_sysconfig import ConfigError, config
+from django_sysconfig.accessor import config
+from django_sysconfig.exceptions import ConfigError
 
 from .base import SubCommand
 

--- a/django_sysconfig/management/commands/_config/import_.py
+++ b/django_sysconfig/management/commands/_config/import_.py
@@ -4,113 +4,140 @@ from django.db import transaction
 from django_sysconfig.accessor import config
 from django_sysconfig.exceptions import ConfigError, ConfigValidationError
 
+from .base import SubCommand
 from .common import confirm, load_json
-from .options import resolve_skip_prompt
+from .options import add_dry_run, add_skip_prompt, resolve_skip_prompt
 
 
-def handle_import(command, **options):
-    """Load a JSON export and persist all contained config values."""
-    dry_run = options["dry_run"]
-    use_stdin = options["stdin"]
-    skip_callbacks = options["skip_on_save_callbacks"]
-    skip_prompt = resolve_skip_prompt(command, options)
-    file_path = options.get("file")
+class ImportCommand(SubCommand):
+    name = "import"
+    help = "Import configuration values from a JSON file"
 
-    # 1. Validate args
-    if use_stdin and file_path:
-        raise CommandError("--stdin and --file are mutually exclusive")
-    if not use_stdin and not file_path:
-        raise CommandError("Provide a file path via --file/-i or use --stdin")
-    if file_path and not file_path.endswith(".json"):
-        raise CommandError("Input file must have a .json extension")
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--file",
+            "-i",
+            help="Input file path (.json)",
+        )
+        parser.add_argument(
+            "--stdin",
+            action="store_true",
+            help="Read JSON from stdin instead of a file",
+        )
+        add_dry_run(parser)
+        parser.add_argument(
+            "-S",
+            "--skip-on-save-callbacks",
+            action="store_true",
+            help="Skip on_save callbacks for all fields in this import batch.",
+        )
+        add_skip_prompt(parser)
 
-    # 2. Load
-    data = load_json(command, file_path, use_stdin)
+    def handle(self, command, **options):
+        """Load a JSON export and persist all contained config values."""
+        dry_run = options["dry_run"]
+        use_stdin = options["stdin"]
+        skip_callbacks = options["skip_on_save_callbacks"]
+        skip_prompt = resolve_skip_prompt(command, options)
+        file_path = options.get("file")
 
-    config_data = data.get("config", {})
-    if not config_data:
-        raise CommandError("No config data found in file")
+        # 1. Validate args
+        if use_stdin and file_path:
+            raise CommandError("--stdin and --file are mutually exclusive")
+        if not use_stdin and not file_path:
+            raise CommandError("Provide a file path via --file/-i or use --stdin")
+        if file_path and not file_path.endswith(".json"):
+            raise CommandError("Input file must have a .json extension")
 
-    # 3. Validate structure before attempting to iterate
-    if not isinstance(config_data, dict):
-        raise CommandError("Invalid format: 'config' must be a JSON object")
+        # 2. Load
+        data = load_json(command, file_path, use_stdin)
 
-    for app, sections in config_data.items():
-        if not isinstance(sections, dict):
-            raise CommandError(
-                f"Invalid format: expected an object for app '{app}', "
-                f"got {type(sections).__name__}"
-            )
-        for section, fields in sections.items():
-            if not isinstance(fields, dict):
+        config_data = data.get("config", {})
+        if not config_data:
+            raise CommandError("No config data found in file")
+
+        # 3. Validate structure before attempting to iterate
+        if not isinstance(config_data, dict):
+            raise CommandError("Invalid format: 'config' must be a JSON object")
+
+        for app, sections in config_data.items():
+            if not isinstance(sections, dict):
                 raise CommandError(
-                    f"Invalid format: expected an object for '{app}.{section}', "
-                    f"got {type(fields).__name__}"
+                    f"Invalid format: expected an object for app '{app}', "
+                    f"got {type(sections).__name__}"
                 )
-            for field in fields:
-                if not isinstance(field, str):
+            for section, fields in sections.items():
+                if not isinstance(fields, dict):
                     raise CommandError(
-                        f"Invalid format: field keys must be strings "
-                        f"in '{app}.{section}'"
+                        f"Invalid format: expected an object for '{app}.{section}', "
+                        f"got {type(fields).__name__}"
                     )
+                for field in fields:
+                    if not isinstance(field, str):
+                        raise CommandError(
+                            f"Invalid format: field keys must be strings "
+                            f"in '{app}.{section}'"
+                        )
 
-    paths = [
-        (f"{app}.{section}.{field}", value)
-        for app, sections in config_data.items()
-        for section, fields in sections.items()
-        for field, value in fields.items()
-    ]
+        paths = [
+            (f"{app}.{section}.{field}", value)
+            for app, sections in config_data.items()
+            for section, fields in sections.items()
+            for field, value in fields.items()
+        ]
 
-    # 4. Confirm.
-    #
-    # Skipped for dry-run, for --no-input/--force, and when reading from stdin.
-    # load_json() has already drained sys.stdin by this point, so prompting
-    # would hit an exhausted stream and raise EOFError; a piped stdin is
-    # non-interactive by definition, so there is nobody to ask.
-    if not dry_run and not skip_prompt and not use_stdin:
-        confirm(
-            command,
-            f"This will override current configuration values from '{file_path}'. "
-            "This cannot be undone.",
-        )
+        # 4. Confirm.
+        #
+        # Skipped for dry-run, for --no-input/--force, and when reading from stdin.
+        # load_json() has already drained sys.stdin by this point, so prompting
+        # would hit an exhausted stream and raise EOFError; a piped stdin is
+        # non-interactive by definition, so there is nobody to ask.
+        if not dry_run and not skip_prompt and not use_stdin:
+            confirm(
+                command,
+                f"This will override current configuration values from '{file_path}'. "
+                "This cannot be undone.",
+            )
 
-    if dry_run:
-        command.stdout.write(
-            command.style.WARNING("Dry run — no values will be saved\n")
-        )
+        if dry_run:
+            command.stdout.write(
+                command.style.WARNING("Dry run — no values will be saved\n")
+            )
 
-        # Exercise the full import path inside a transaction that is always
-        # rolled back — this runs path resolution, frontend-model coercion,
-        # serialization, and field validators, so a dry-run failure means the
-        # real import would also fail.
+            # Exercise the full import path inside a transaction that is always
+            # rolled back — this runs path resolution, frontend-model coercion,
+            # serialization, and field validators, so a dry-run failure means the
+            # real import would also fail.
 
-        errors = []
+            errors = []
+            try:
+                with transaction.atomic():
+                    config.set_many(dict(paths), skip_on_save_callbacks=True)
+                    transaction.set_rollback(True)
+            except (ConfigValidationError, ConfigError) as e:
+                errors.append(str(e))
+
+            if errors:
+                raise CommandError(
+                    "Dry run failed — import would not succeed:\n"
+                    + "\n".join(f"  • {err}" for err in errors)
+                )
+
+            command.stdout.write(
+                command.style.SUCCESS(
+                    f"✔ Dry run passed — {len(paths)} value(s) look valid"
+                )
+            )
+            return
+
+        # 5. Execute
         try:
-            with transaction.atomic():
-                config.set_many(dict(paths), skip_on_save_callbacks=True)
-                transaction.set_rollback(True)
+            config.set_many(dict(paths), skip_on_save_callbacks=skip_callbacks)
         except (ConfigValidationError, ConfigError) as e:
-            errors.append(str(e))
-
-        if errors:
             raise CommandError(
-                "Dry run failed — import would not succeed:\n"
-                + "\n".join(f"  • {err}" for err in errors)
-            )
+                f"Import aborted — all changes rolled back:\n  • {e}"
+            ) from e
 
         command.stdout.write(
-            command.style.SUCCESS(
-                f"✔ Dry run passed — {len(paths)} value(s) look valid"
-            )
+            command.style.SUCCESS(f"✔ Import complete — {len(paths)} value(s) set")
         )
-        return
-
-    # 5. Execute
-    try:
-        config.set_many(dict(paths), skip_on_save_callbacks=skip_callbacks)
-    except (ConfigValidationError, ConfigError) as e:
-        raise CommandError(f"Import aborted — all changes rolled back:\n  • {e}") from e
-
-    command.stdout.write(
-        command.style.SUCCESS(f"✔ Import complete — {len(paths)} value(s) set")
-    )

--- a/django_sysconfig/management/commands/_config/reset.py
+++ b/django_sysconfig/management/commands/_config/reset.py
@@ -3,22 +3,32 @@ from django.core.management.base import CommandError
 from django_sysconfig.accessor import config
 from django_sysconfig.exceptions import ConfigError
 
+from .base import SubCommand
 from .common import confirm
-from .options import resolve_skip_prompt
+from .options import add_skip_prompt, resolve_skip_prompt
 
 
-def handle_reset(command, **options):
-    """Reset a config path to its field default, with optional confirmation."""
-    path = options["path"]
+class ResetCommand(SubCommand):
+    name = "reset"
+    help = "Reset a configuration value to its field default"
 
-    if not resolve_skip_prompt(command, options):
-        confirm(
-            command,
-            f"This will reset '{path}' to its field default. This cannot be undone.",
-        )
+    def add_arguments(self, parser):
+        parser.add_argument("path", help="Config path in app.section.field format")
+        add_skip_prompt(parser)
 
-    try:
-        config.reset(path)
-        command.stdout.write(command.style.SUCCESS(f"✔ {path} reset to default"))
-    except ConfigError as e:
-        raise CommandError(str(e)) from e
+    def handle(self, command, **options):
+        """Reset a config path to its field default, with optional confirmation."""
+        path = options["path"]
+
+        if not resolve_skip_prompt(command, options):
+            confirm(
+                command,
+                f"This will reset '{path}' to its field default. "
+                "This cannot be undone.",
+            )
+
+        try:
+            config.reset(path)
+            command.stdout.write(command.style.SUCCESS(f"✔ {path} reset to default"))
+        except ConfigError as e:
+            raise CommandError(str(e)) from e

--- a/django_sysconfig/management/commands/_config/set.py
+++ b/django_sysconfig/management/commands/_config/set.py
@@ -4,38 +4,50 @@ from django.db import transaction
 from django_sysconfig.accessor import config
 from django_sysconfig.exceptions import ConfigError, ConfigValidationError
 
+from .base import SubCommand
+from .options import add_dry_run
 
-def handle_set(command, **options):
-    """Parse and persist a single config value."""
-    path = options["path"]
-    raw = options["value"]
-    dry_run = options["dry_run"]
 
-    try:
-        app_label, section, field_name = config._parse_path(path)
-        field = config._get_field(app_label, section, field_name)
-        parsed = field.get_frontend_model_instance().get_value(raw)
+class SetCommand(SubCommand):
+    name = "set"
+    help = "Set a configuration value"
 
-        with transaction.atomic():
-            config.set(path, parsed)
+    def add_arguments(self, parser):
+        parser.add_argument("path", help="Config path in app.section.field format")
+        parser.add_argument("value", help="Value to set")
+        add_dry_run(parser)
 
-            if dry_run:
+    def handle(self, command, **options):
+        """Parse and persist a single config value."""
+        path = options["path"]
+        raw = options["value"]
+        dry_run = options["dry_run"]
+
+        try:
+            app_label, section, field_name = config._parse_path(path)
+            field = config._get_field(app_label, section, field_name)
+            parsed = field.get_frontend_model_instance().get_value(raw)
+
+            with transaction.atomic():
+                config.set(path, parsed)
+
+                if dry_run:
+                    command.stdout.write(
+                        command.style.SUCCESS(f"✔ Validation passed for '{path}'")
+                    )
+                    command.stdout.write(
+                        command.style.WARNING("Dry run — no values will be saved")
+                    )
+                    transaction.set_rollback(True)
+                    return
+
                 command.stdout.write(
-                    command.style.SUCCESS(f"✔ Validation passed for '{path}'")
+                    command.style.SUCCESS(f"✔ {path} updated successfully")
                 )
-                command.stdout.write(
-                    command.style.WARNING("Dry run — no values will be saved")
-                )
-                transaction.set_rollback(True)
-                return
 
-            command.stdout.write(
-                command.style.SUCCESS(f"✔ {path} updated successfully")
-            )
+        except ConfigValidationError as e:
+            errors = "\n".join(f"  • {err}" for err in e.errors)
+            raise CommandError(f"Validation failed for {path}:\n{errors}") from e
 
-    except ConfigValidationError as e:
-        errors = "\n".join(f"  • {err}" for err in e.errors)
-        raise CommandError(f"Validation failed for {path}:\n{errors}") from e
-
-    except ConfigError as e:
-        raise CommandError(str(e)) from e
+        except ConfigError as e:
+            raise CommandError(str(e)) from e

--- a/django_sysconfig/management/commands/config.py
+++ b/django_sysconfig/management/commands/config.py
@@ -27,7 +27,7 @@ class Command(BaseCommand):
         subparsers.required = True
 
         for sub in SUBCOMMANDS:
-            sub.add_arguments(subparsers.add_parser(sub.name, help=sub.help))
+            sub.register(subparsers)
 
     def handle(self, *args, **options):
         _BY_NAME[options["subcommand"]].handle(self, **options)

--- a/django_sysconfig/management/commands/config.py
+++ b/django_sysconfig/management/commands/config.py
@@ -1,11 +1,18 @@
 from django.core.management.base import BaseCommand, CommandParser
 
 from ._config.export import handle_export
-from ._config.get import handle_get
+from ._config.get import GetCommand
 from ._config.import_ import handle_import
 from ._config.options import add_dry_run, add_skip_prompt
 from ._config.reset import handle_reset
 from ._config.set import handle_set
+
+# Subcommands migrated to the SubCommand class form. Each owns both its flags
+# and its handler. The remaining subcommands below are still declared inline
+# and dispatched through LEGACY_HANDLERS; they are being converted one at a
+# time, after which both this comment and LEGACY_HANDLERS disappear.
+SUBCOMMANDS = (GetCommand(),)
+_BY_NAME = {sub.name: sub for sub in SUBCOMMANDS}
 
 
 class Command(BaseCommand):
@@ -15,9 +22,8 @@ class Command(BaseCommand):
         subparsers = parser.add_subparsers(dest="subcommand", metavar="subcommand")
         subparsers.required = True
 
-        # --- get ---
-        get_parser = subparsers.add_parser("get", help="Get a configuration value")
-        get_parser.add_argument("path", help="Config path in app.section.field format")
+        for sub in SUBCOMMANDS:
+            sub.add_arguments(subparsers.add_parser(sub.name, help=sub.help))
 
         # --- set ---
         set_parser = subparsers.add_parser("set", help="Set a configuration value")
@@ -72,11 +78,20 @@ class Command(BaseCommand):
         add_skip_prompt(import_parser)
 
     def handle(self, *args, **options):
-        handlers = {
-            "get": handle_get,
-            "set": handle_set,
-            "reset": handle_reset,
-            "export": handle_export,
-            "import": handle_import,
-        }
-        handlers[options["subcommand"]](self, **options)
+        name = options["subcommand"]
+
+        sub = _BY_NAME.get(name)
+        if sub is not None:
+            sub.handle(self, **options)
+            return
+
+        LEGACY_HANDLERS[name](self, **options)
+
+
+# Not-yet-migrated subcommands. Shrinks to empty as each one moves to a class.
+LEGACY_HANDLERS = {
+    "set": handle_set,
+    "reset": handle_reset,
+    "export": handle_export,
+    "import": handle_import,
+}

--- a/django_sysconfig/management/commands/config.py
+++ b/django_sysconfig/management/commands/config.py
@@ -1,6 +1,6 @@
 from django.core.management.base import BaseCommand, CommandParser
 
-from ._config.export import handle_export
+from ._config.export import ExportCommand
 from ._config.get import GetCommand
 from ._config.import_ import handle_import
 from ._config.options import add_dry_run, add_skip_prompt
@@ -11,7 +11,7 @@ from ._config.set import SetCommand
 # and its handler. The remaining subcommands below are still declared inline
 # and dispatched through LEGACY_HANDLERS; they are being converted one at a
 # time, after which both this comment and LEGACY_HANDLERS disappear.
-SUBCOMMANDS = (GetCommand(), SetCommand(), ResetCommand())
+SUBCOMMANDS = (GetCommand(), SetCommand(), ResetCommand(), ExportCommand())
 _BY_NAME = {sub.name: sub for sub in SUBCOMMANDS}
 
 
@@ -24,20 +24,6 @@ class Command(BaseCommand):
 
         for sub in SUBCOMMANDS:
             sub.add_arguments(subparsers.add_parser(sub.name, help=sub.help))
-
-        # --- export ---
-        export_parser = subparsers.add_parser(
-            "export", help="Export configuration values to a JSON file"
-        )
-        export_parser.add_argument(
-            "app", nargs="?", help="App label to export (exports all apps if omitted)"
-        )
-        export_parser.add_argument(
-            "--output",
-            "-o",
-            default="config_export.json",
-            help="Output file path (default: config_export.json)",
-        )
 
         # --- import ---
         import_parser = subparsers.add_parser(
@@ -75,6 +61,5 @@ class Command(BaseCommand):
 
 # Not-yet-migrated subcommands. Shrinks to empty as each one moves to a class.
 LEGACY_HANDLERS = {
-    "export": handle_export,
     "import": handle_import,
 }

--- a/django_sysconfig/management/commands/config.py
+++ b/django_sysconfig/management/commands/config.py
@@ -4,14 +4,14 @@ from ._config.export import handle_export
 from ._config.get import GetCommand
 from ._config.import_ import handle_import
 from ._config.options import add_dry_run, add_skip_prompt
-from ._config.reset import handle_reset
+from ._config.reset import ResetCommand
 from ._config.set import SetCommand
 
 # Subcommands migrated to the SubCommand class form. Each owns both its flags
 # and its handler. The remaining subcommands below are still declared inline
 # and dispatched through LEGACY_HANDLERS; they are being converted one at a
 # time, after which both this comment and LEGACY_HANDLERS disappear.
-SUBCOMMANDS = (GetCommand(), SetCommand())
+SUBCOMMANDS = (GetCommand(), SetCommand(), ResetCommand())
 _BY_NAME = {sub.name: sub for sub in SUBCOMMANDS}
 
 
@@ -24,15 +24,6 @@ class Command(BaseCommand):
 
         for sub in SUBCOMMANDS:
             sub.add_arguments(subparsers.add_parser(sub.name, help=sub.help))
-
-        # --- reset ---
-        reset_parser = subparsers.add_parser(
-            "reset", help="Reset a configuration value to its field default"
-        )
-        reset_parser.add_argument(
-            "path", help="Config path in app.section.field format"
-        )
-        add_skip_prompt(reset_parser)
 
         # --- export ---
         export_parser = subparsers.add_parser(
@@ -84,7 +75,6 @@ class Command(BaseCommand):
 
 # Not-yet-migrated subcommands. Shrinks to empty as each one moves to a class.
 LEGACY_HANDLERS = {
-    "reset": handle_reset,
     "export": handle_export,
     "import": handle_import,
 }

--- a/django_sysconfig/management/commands/config.py
+++ b/django_sysconfig/management/commands/config.py
@@ -2,16 +2,20 @@ from django.core.management.base import BaseCommand, CommandParser
 
 from ._config.export import ExportCommand
 from ._config.get import GetCommand
-from ._config.import_ import handle_import
-from ._config.options import add_dry_run, add_skip_prompt
+from ._config.import_ import ImportCommand
 from ._config.reset import ResetCommand
 from ._config.set import SetCommand
 
-# Subcommands migrated to the SubCommand class form. Each owns both its flags
-# and its handler. The remaining subcommands below are still declared inline
-# and dispatched through LEGACY_HANDLERS; they are being converted one at a
-# time, after which both this comment and LEGACY_HANDLERS disappear.
-SUBCOMMANDS = (GetCommand(), SetCommand(), ResetCommand(), ExportCommand())
+# Every subcommand owns both its flags and its handler. Adding one means
+# writing a SubCommand subclass and listing it here — this module does not
+# otherwise grow.
+SUBCOMMANDS = (
+    GetCommand(),
+    SetCommand(),
+    ResetCommand(),
+    ExportCommand(),
+    ImportCommand(),
+)
 _BY_NAME = {sub.name: sub for sub in SUBCOMMANDS}
 
 
@@ -25,41 +29,5 @@ class Command(BaseCommand):
         for sub in SUBCOMMANDS:
             sub.add_arguments(subparsers.add_parser(sub.name, help=sub.help))
 
-        # --- import ---
-        import_parser = subparsers.add_parser(
-            "import", help="Import configuration values from a JSON file"
-        )
-        import_parser.add_argument(
-            "--file",
-            "-i",
-            help="Input file path (.json)",
-        )
-        import_parser.add_argument(
-            "--stdin",
-            action="store_true",
-            help="Read JSON from stdin instead of a file",
-        )
-        add_dry_run(import_parser)
-        import_parser.add_argument(
-            "-S",
-            "--skip-on-save-callbacks",
-            action="store_true",
-            help="Skip on_save callbacks for all fields in this import batch.",
-        )
-        add_skip_prompt(import_parser)
-
     def handle(self, *args, **options):
-        name = options["subcommand"]
-
-        sub = _BY_NAME.get(name)
-        if sub is not None:
-            sub.handle(self, **options)
-            return
-
-        LEGACY_HANDLERS[name](self, **options)
-
-
-# Not-yet-migrated subcommands. Shrinks to empty as each one moves to a class.
-LEGACY_HANDLERS = {
-    "import": handle_import,
-}
+        _BY_NAME[options["subcommand"]].handle(self, **options)

--- a/django_sysconfig/management/commands/config.py
+++ b/django_sysconfig/management/commands/config.py
@@ -5,13 +5,13 @@ from ._config.get import GetCommand
 from ._config.import_ import handle_import
 from ._config.options import add_dry_run, add_skip_prompt
 from ._config.reset import handle_reset
-from ._config.set import handle_set
+from ._config.set import SetCommand
 
 # Subcommands migrated to the SubCommand class form. Each owns both its flags
 # and its handler. The remaining subcommands below are still declared inline
 # and dispatched through LEGACY_HANDLERS; they are being converted one at a
 # time, after which both this comment and LEGACY_HANDLERS disappear.
-SUBCOMMANDS = (GetCommand(),)
+SUBCOMMANDS = (GetCommand(), SetCommand())
 _BY_NAME = {sub.name: sub for sub in SUBCOMMANDS}
 
 
@@ -24,12 +24,6 @@ class Command(BaseCommand):
 
         for sub in SUBCOMMANDS:
             sub.add_arguments(subparsers.add_parser(sub.name, help=sub.help))
-
-        # --- set ---
-        set_parser = subparsers.add_parser("set", help="Set a configuration value")
-        set_parser.add_argument("path", help="Config path in app.section.field format")
-        set_parser.add_argument("value", help="Value to set")
-        add_dry_run(set_parser)
 
         # --- reset ---
         reset_parser = subparsers.add_parser(
@@ -90,7 +84,6 @@ class Command(BaseCommand):
 
 # Not-yet-migrated subcommands. Shrinks to empty as each one moves to a class.
 LEGACY_HANDLERS = {
-    "set": handle_set,
     "reset": handle_reset,
     "export": handle_export,
     "import": handle_import,


### PR DESCRIPTION
## Description

Follow-up refactor stacked on #101. That PR split the monolithic `config` command into one module per subcommand, but left the wiring split across two places: every subcommand's flags were declared in `config.py`'s `add_arguments`, while the code reading those flags lived in `_config/<name>.py`. Adding or renaming a flag meant editing two files, and nothing enforced that they stayed in sync.

This PR introduces a `SubCommand` base class so each subcommand owns **both** its flags and its handler in a single module.

> **Stacked PR** — targets `refactor/config-command`, not `develop`. Retarget to `develop` once #101 merges.

Closes #<!-- issue number -->

---

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [x] 🔧 Internal refactor (no behaviour change)
- [ ] 📖 Documentation update
- [ ] 🧪 Tests only
- [ ] 🔒 Security fix

---

## Changes Made

- Add `_config/base.py` with `SubCommand`, an ABC exposing `name`, `help`, `add_arguments(parser)` and an abstract `handle(command, **options)`. Instances are constructed once at import time, so subclasses are required to be stateless.
- Convert all five subcommands (`get`, `set`, `reset`, `export`, `import`) from module-level functions to `SubCommand` subclasses, moving each one's `add_argument` calls out of `config.py` and next to its handler.
- Shrink `config.py` from 82 lines to 33. It now holds a `SUBCOMMANDS` tuple and a name lookup; registering a new subcommand means writing a subclass and adding it to that tuple, and this module stops growing.
- Keep `SubCommand.add_arguments` **concrete** rather than abstract — a subcommand may legitimately take no arguments, mirroring `BaseCommand.add_arguments`, which is itself a no-op. Carries a targeted `# noqa: B027` with the rationale in the docstring, rather than loosening the project-wide ruff config.
- Fix an import inconsistency in `get.py`: it imported `config` and `ConfigError` from the package root while the other four modules import from `django_sysconfig.accessor` / `django_sysconfig.exceptions`.

### On the `get.py` import

More than cosmetic. `django_sysconfig/__init__.py` documents:

> Import `config` from `config.accessor` to avoid circular imports during Django app initialization.

The root-level import resolved only through the lazy `__getattr__` shim in `__init__.py`. Management commands load *during* app initialization — precisely the case that note warns about — so this module was depending on the escape hatch the package tells you not to use. Not a live bug, but not something to leave in a command module. Verified behaviour-neutral before changing: `django_sysconfig.config is accessor.config` → `True`, and the two `ConfigError` names are the same object.

---

## Django / Python Compatibility

- [ ] Tested on Django 4.2 (LTS)
- [ ] Tested on Django 5.x
- [ ] Tested on Python 3.11+
- [x] Not applicable

Pure-Python restructuring of management-command wiring; no version-sensitive APIs touched.

---

## Checklist

- [x] My code follows the existing code style
- [x] I have added or updated tests to cover my changes
- [x] All existing tests pass (`python -m pytest` or `python manage.py test`)
- [x] I have updated the documentation if needed
- [x] I have added an entry to `CHANGELOG.md` (if user-facing change)
- [x] I have checked for any migrations needed (`makemigrations --check`)

Notes on the above:

- **Tests:** none added or changed, deliberately. **Not one test file is touched across all 8 commits** — that is the correctness argument for a pure refactor. 347 tests pass.
- **Docs / CHANGELOG:** no entry. Nothing user-facing changed; the CLI surface is byte-identical.
- **Migrations:** no model changes.

---

## Breaking Changes

N/A. The CLI surface is unchanged — same subcommands, same flags, same help text, same output. Every change is internal to how the parser is assembled.

Verified by diffing `--help` output for `config` and for each of the five subcommands against `refactor/config-command`.

---

## Additional Notes

**Why not a registry / decorator?** An explicit `SUBCOMMANDS` tuple was chosen over auto-discovery. Registration order is the order subcommands appear in `--help`, and an explicit tuple makes that order reviewable in the diff instead of an emergent property of import order. Order was checked after each conversion step: `get, set, reset, export, import`.

**One cosmetic diff to know about:** `export.py` shows a reflowed line that is not a logic change. Moving function bodies into methods added a level of indentation, which pushed one line past the limit, and black reflowed it.

Best reviewed commit-by-commit — the base class lands first, then one commit per subcommand.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added structured configuration subcommands for getting, setting, resetting, importing, and exporting values.
  * Added command-line help text and argument handling for each configuration operation.
  * Added support for dry runs, confirmation controls, JSON import/export, and standard input imports.
* **Refactor**
  * Unified configuration command behavior under a consistent subcommand interface while preserving existing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->